### PR TITLE
Build hygiene: deps, ProGuard, Gradle cache, CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main, master]
+  push:
+    branches: [main, master]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build:
+    name: Build & Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/master' }}
+
+      - name: Validate Gradle wrapper
+        uses: gradle/actions/wrapper-validation@v4
+
+      - name: Assemble debug
+        run: ./gradlew :app:assembleDebug --stacktrace
+
+      - name: Unit tests
+        run: ./gradlew testDebugUnitTest --stacktrace
+
+      - name: Android Lint
+        run: ./gradlew lintDebug --stacktrace
+
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports
+          path: |
+            **/build/reports/tests/
+            **/build/reports/lint-results-*.html
+          if-no-files-found: ignore

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -31,5 +31,54 @@
 -keep class com.google.crypto.tink.** { *; }
 -keep class flow.network.dto.** { *; }
 
+# kotlinx.serialization: keep generated serializers and Companion-held $serializer fields
+-keepattributes *Annotation*, InnerClasses
+-dontnote kotlinx.serialization.AnnotationsKt
+-keepclasseswithmembers class **.*$Companion {
+    kotlinx.serialization.KSerializer serializer(...);
+}
+-if class **.*$Companion {
+    kotlinx.serialization.KSerializer serializer(...);
+}
+-keepclassmembers class <1>.<2> {
+    <1>.<2>$Companion Companion;
+}
+-keepclasseswithmembers class * {
+    public static **$Companion Companion;
+}
+
+# Hilt / Dagger
+-keep class dagger.hilt.** { *; }
+-keep class * extends dagger.hilt.android.lifecycle.HiltViewModel
+-keep,allowobfuscation @interface dagger.hilt.**
+-keep,allowobfuscation @interface javax.inject.**
+
+# Ktor client/server use reflection for engines and plugins
+-keep class io.ktor.** { *; }
+-keepclassmembers class io.ktor.** { *; }
+-dontwarn io.ktor.**
+-dontwarn io.netty.**
+-dontwarn org.slf4j.**
+
+# OkHttp / Okio (transitive via Ktor + Coil)
+-dontwarn okhttp3.internal.platform.**
+-dontwarn org.conscrypt.**
+-dontwarn org.bouncycastle.**
+
+# Coroutines: drop service-loader warnings on Android
+-dontwarn kotlinx.coroutines.debug.**
+
+# Orbit MVI uses reflection on container/intent classes
+-keep class org.orbitmvi.orbit.** { *; }
+
+# Jsoup occasionally referenced reflectively by parsers
+-keep class org.jsoup.** { *; }
+-dontwarn org.jsoup.**
+
+# Room: generated _Impl classes are accessed by reflection at runtime
+-keep class * extends androidx.room.RoomDatabase
+-keep @androidx.room.Entity class *
+-dontwarn androidx.room.paging.**
+
 -keepattributes SourceFile,LineNumberTable,RuntimeVisibleAnnotations,AnnotationDefault
 -renamesourcefileattribute SourceFile

--- a/core/testing/src/main/kotlin/flow/testing/repository/TestFavoritesRepository.kt
+++ b/core/testing/src/main/kotlin/flow/testing/repository/TestFavoritesRepository.kt
@@ -5,64 +5,78 @@ import flow.models.topic.Topic
 import flow.models.topic.TopicModel
 import flow.models.topic.Torrent
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
 
 class TestFavoritesRepository : FavoritesRepository {
-    override fun observeTopics(): Flow<List<TopicModel<out Topic>>> {
-        TODO("Not yet implemented")
-    }
+    private val topicsFlow: MutableStateFlow<List<TopicModel<Topic>>> = MutableStateFlow(emptyList())
 
-    override fun observeIds(): Flow<List<String>> {
-        TODO("Not yet implemented")
-    }
+    override fun observeTopics(): Flow<List<TopicModel<out Topic>>> = topicsFlow
 
-    override fun observeUpdatedIds(): Flow<List<String>> {
-        TODO("Not yet implemented")
-    }
+    override fun observeIds(): Flow<List<String>> =
+        topicsFlow.map { topics -> topics.map { it.topic.id } }
 
-    override suspend fun getIds(): List<String> {
-        TODO("Not yet implemented")
-    }
+    override fun observeUpdatedIds(): Flow<List<String>> =
+        topicsFlow.map { topics -> topics.filter { it.hasUpdate }.map { it.topic.id } }
 
-    override suspend fun getTorrents(): List<Torrent> {
-        TODO("Not yet implemented")
-    }
+    override suspend fun getIds(): List<String> = topicsFlow.value.map { it.topic.id }
 
-    override suspend fun contains(id: String): Boolean {
-        TODO("Not yet implemented")
-    }
+    override suspend fun getTorrents(): List<Torrent> =
+        topicsFlow.value.mapNotNull { it.topic as? Torrent }
+
+    override suspend fun contains(id: String): Boolean =
+        topicsFlow.value.any { it.topic.id == id }
 
     override suspend fun add(topic: Topic) {
-        TODO("Not yet implemented")
+        topicsFlow.update { current ->
+            if (current.any { it.topic.id == topic.id }) current
+            else current + TopicModel<Topic>(topic = topic, isFavorite = true)
+        }
     }
 
     override suspend fun add(topics: List<Topic>) {
-        TODO("Not yet implemented")
+        topics.forEach { add(it) }
     }
 
     override suspend fun remove(topic: Topic) {
-        TODO("Not yet implemented")
+        removeById(topic.id)
     }
 
     override suspend fun remove(topics: List<Topic>) {
-        TODO("Not yet implemented")
+        removeById(topics.map { it.id })
     }
 
     override suspend fun removeById(id: String) {
-        TODO("Not yet implemented")
+        topicsFlow.update { current -> current.filterNot { it.topic.id == id } }
     }
 
     override suspend fun removeById(ids: List<String>) {
-        TODO("Not yet implemented")
+        val idSet = ids.toSet()
+        topicsFlow.update { current -> current.filterNot { it.topic.id in idSet } }
     }
 
     override suspend fun updateTorrent(torrent: Torrent, hasUpdate: Boolean) {
-        TODO("Not yet implemented")
+        topicsFlow.update { current ->
+            current.map { model ->
+                if (model.topic.id == torrent.id) {
+                    TopicModel<Topic>(topic = torrent, isFavorite = true, hasUpdate = hasUpdate)
+                } else {
+                    model
+                }
+            }
+        }
     }
 
     override suspend fun markVisited(id: String) {
-        TODO("Not yet implemented")
+        topicsFlow.update { current ->
+            current.map { model ->
+                if (model.topic.id == id) model.copy(isVisited = true, hasUpdate = false) else model
+            }
+        }
     }
 
     override suspend fun clear() {
+        topicsFlow.update { emptyList() }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,11 +6,12 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
-# When configured, Gradle will run in incubating parallel mode.
-# This option should only be used with decoupled projects. More details, visit
-# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
+org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
+# Parallel + on-demand configuration significantly speeds up builds for
+# multi-module projects (this repo has ~40 modules).
+org.gradle.parallel=true
+org.gradle.configureondemand=true
+org.gradle.caching=true
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app"s APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,7 @@ firebaseCrashlyticsGradlePlugin = "3.0.4"
 googleServicesGradlePlugin = "4.4.2"
 hilt = "2.54"
 hiltExt = "1.2.0"
-jsoup = "1.15.3"
+jsoup = "1.18.1"
 junit4 = "4.13.2"
 koin = "3.4.0"
 kotlin = "2.1.0"
@@ -81,7 +81,7 @@ hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.r
 hilt-dagger-compiler = { group = "com.google.dagger", name = "dagger-compiler", version.ref = "hilt" }
 hilt-work = { group = "androidx.hilt", name = "hilt-work", version.ref = "hiltExt" }
 javax-inject = { group = "javax.inject", name = "javax.inject", version = "1" }
-json = { group = "org.json", name = "json", version = "20220924" }
+json = { group = "org.json", name = "json", version = "20240303" }
 jsoup = { group = "org.jsoup", name = "jsoup", version.ref = "jsoup" }
 junit4 = { group = "junit", name = "junit", version.ref = "junit4" }
 koin = { group = "io.insert-koin", name = "koin-core", version.ref = "koin" }


### PR DESCRIPTION
## Summary

A first pass at the high-leverage, low-risk quick wins from the recent improvement audit. Each change is isolated so anything that turns out to misbehave can be reverted independently.

### Dependencies (`gradle/libs.versions.toml`)
- `jsoup`: `1.15.3` → `1.18.1`
- `org.json`: `20220924` → `20240303`

Both are bug-fix/security patches and not API-breaking.

Deliberately left for follow-ups:
- `androidxSecurity` is still on `1.1.0-alpha03` — alpha-to-alpha jumps can break API and need their own PR.
- Ktor `2.3.1` → `3.x` and `accompanist` cleanup are larger migrations.

### ProGuard (`app/proguard-rules.pro`)
Release builds run with `isRemoveUnusedCode = true` + `isOptimizeCode = true` but the rules file was nearly empty. Added safe-default keep/dontwarn rules for:
- kotlinx.serialization (`Companion.serializer(...)` retention)
- Hilt / Dagger generated classes and inject annotations
- Ktor client + server engines
- Orbit MVI
- Room (`*_Impl`, `@Entity`)
- Jsoup
- Coroutines, OkHttp, Netty, slf4j warning suppression

### Gradle (`gradle.properties`)
- Enabled `org.gradle.parallel`, `org.gradle.configureondemand`, `org.gradle.caching`
- Bumped daemon heap from 2 GiB to 4 GiB — useful on a project with ~40 modules

### CI (`.github/workflows/ci.yml`)
Repo had no CI. Added a minimal workflow that runs on PRs and pushes to `main`/`master`:
- JDK 17 (Temurin) + Gradle wrapper validation
- `:app:assembleDebug`
- `testDebugUnitTest`
- `lintDebug`
- Uploads test + lint reports as artifacts on failure

### Test fixture (`core/testing/.../TestFavoritesRepository.kt`)
Previously every method threw `TODO("Not yet implemented")`, making the test double misleading. Replaced with a working in-memory `MutableStateFlow`-backed implementation that mirrors the style of `TestSearchHistoryRepository`.

## Test plan
- [ ] CI workflow runs cleanly on this PR (this will be the first run, so monitor closely)
- [ ] Local `./gradlew :app:assembleRelease` succeeds with new ProGuard rules
- [ ] Local `./gradlew :app:assembleDebug` finishes faster with parallel+caching enabled
- [ ] Spot-check release APK launches and exercises the favorites / search / topic flows that touch jsoup / org.json / Ktor / serialization

https://claude.ai/code/session_016VLE8mzw6CbqNWvChnucHV

---
_Generated by [Claude Code](https://claude.ai/code/session_016VLE8mzw6CbqNWvChnucHV)_