### PR TITLE
Add GitHub Actions for build and release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,66 @@
+name: Build
+
+on:
+  pull_request:
+    branches: [ "**" ]
+  push:
+    branches: [ "main", "master" ]
+
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Lint, test, assemble debug
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Decode google-services.json
+        env:
+          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+        run: |
+          if [ -z "$GOOGLE_SERVICES_JSON" ]; then
+            echo "::error::GOOGLE_SERVICES_JSON secret is not set"
+            exit 1
+          fi
+          echo "$GOOGLE_SERVICES_JSON" | base64 --decode > app/google-services.json
+
+      - name: Lint
+        run: ./gradlew :app:lintDebug --stacktrace
+
+      - name: Unit tests
+        run: ./gradlew testDebugUnitTest --stacktrace
+
+      - name: Assemble debug APK
+        run: ./gradlew :app:assembleDebug --stacktrace
+
+      - name: Upload debug APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: flow-debug-apk
+          path: app/build/outputs/apk/debug/*.apk
+          if-no-files-found: error
+
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports
+          path: |
+            **/build/reports/tests/
+            **/build/test-results/
+          if-no-files-found: ignore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,87 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build and publish release
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Decode google-services.json
+        env:
+          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+        run: |
+          if [ -z "$GOOGLE_SERVICES_JSON" ]; then
+            echo "::error::GOOGLE_SERVICES_JSON secret is not set"
+            exit 1
+          fi
+          echo "$GOOGLE_SERVICES_JSON" | base64 --decode > app/google-services.json
+
+      - name: Decode signing keystore
+        env:
+          KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+        run: |
+          if [ -z "$KEYSTORE_BASE64" ]; then
+            echo "::error::KEYSTORE_BASE64 secret is not set"
+            exit 1
+          fi
+          echo "$KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/release.keystore"
+
+      - name: Unit tests
+        run: ./gradlew testReleaseUnitTest --stacktrace
+
+      - name: Assemble release APK and bundle
+        env:
+          KEYSTORE_FILE: ${{ runner.temp }}/release.keystore
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        run: ./gradlew :app:assembleRelease :app:bundleRelease --stacktrace
+
+      - name: Upload release APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: flow-release-apk
+          path: app/build/outputs/apk/release/*.apk
+          if-no-files-found: error
+
+      - name: Upload release bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: flow-release-bundle
+          path: app/build/outputs/bundle/release/*.aab
+          if-no-files-found: error
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ github.ref_name }}
+          tag_name: ${{ github.ref_name }}
+          generate_release_notes: true
+          files: |
+            app/build/outputs/apk/release/*.apk
+            app/build/outputs/bundle/release/*.aab
+
+      - name: Clean up keystore
+        if: always()
+        run: rm -f "$RUNNER_TEMP/release.keystore"

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 .externalNativeBuild
 .cxx
 local.properties
+google-services.json
+*.keystore
+*.jks

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Flow
 
+[![Build](https://github.com/andrikeev/Flow/actions/workflows/build.yml/badge.svg)](https://github.com/andrikeev/Flow/actions/workflows/build.yml)
+[![Release](https://github.com/andrikeev/Flow/actions/workflows/release.yml/badge.svg)](https://github.com/andrikeev/Flow/actions/workflows/release.yml)
+[![Latest release](https://img.shields.io/github/v/release/andrikeev/Flow)](https://github.com/andrikeev/Flow/releases/latest)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
 Flow is an Android mobile app that is an unofficial client for the popular
 Russian torrent tracker website – rutracker.org. With Flow, users can easily
 search and download torrent files, manage their downloads, and stay up-to-date

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,9 +18,25 @@ android {
         buildConfig = true
     }
 
+    val releaseSigningConfig = signingConfigs.create("release") {
+        val storeFilePath = System.getenv("KEYSTORE_FILE")
+            ?: project.findProperty("KEYSTORE_FILE") as String?
+        if (!storeFilePath.isNullOrBlank() && file(storeFilePath).exists()) {
+            storeFile = file(storeFilePath)
+            storePassword = System.getenv("KEYSTORE_PASSWORD")
+                ?: project.findProperty("KEYSTORE_PASSWORD") as String?
+            keyAlias = System.getenv("KEY_ALIAS")
+                ?: project.findProperty("KEY_ALIAS") as String?
+            keyPassword = System.getenv("KEY_PASSWORD")
+                ?: project.findProperty("KEY_PASSWORD") as String?
+        }
+    }
+
     buildTypes {
         release {
-            signingConfig = signingConfigs.getByName("debug")
+            signingConfig = releaseSigningConfig.storeFile
+                ?.let { releaseSigningConfig }
+                ?: signingConfigs.getByName("debug")
             postprocessing {
                 isRemoveUnusedCode = true
                 isRemoveUnusedResources = true


### PR DESCRIPTION
## Summary

- Add `Build` workflow (`.github/workflows/build.yml`): runs lint, unit tests, and assembles a debug APK on every PR and on pushes to `main` / `master`. Uploads the debug APK and test reports as artifacts.
- Add `Release` workflow (`.github/workflows/release.yml`): on `v*` tag push, runs unit tests, builds a signed release APK + AAB, uploads them as artifacts and publishes a GitHub Release with auto-generated notes.
- Wire env-driven release signing config into `app/build.gradle.kts` so CI can supply the keystore via secrets; falls back to debug signing when env vars are absent (local builds still work).
- Update `.gitignore` to keep `google-services.json` and keystores out of the repo.
- Add CI status / latest release / license badges to the README.

## Required GitHub secrets

Add these in Settings → Secrets and variables → Actions before triggering the workflows:

| Secret | Description |
| --- | --- |
| `GOOGLE_SERVICES_JSON` | Base64-encoded contents of `app/google-services.json` |
| `KEYSTORE_BASE64` | Base64-encoded release keystore file |
| `KEYSTORE_PASSWORD` | Keystore password |
| `KEY_ALIAS` | Signing key alias |
| `KEY_PASSWORD` | Signing key password |

To base64-encode on macOS / Linux: `base64 -w0 release.keystore > release.keystore.b64`.

## Test plan

- [ ] Add the required secrets in repository settings.
- [ ] Open a PR — verify the `Build` workflow runs, lint + tests pass, and the debug APK artifact is produced.
- [ ] Push a `vX.Y.Z` tag — verify the `Release` workflow builds a signed APK + AAB and publishes a GitHub Release with the artifacts attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0173E5yG2qs9m4ni3vPrEZoK)_