### PR TITLE
Clean up Orbit MVI usage

### DIFF
--- a/core/common/src/main/kotlin/flow/common/Coroutines.kt
+++ b/core/common/src/main/kotlin/flow/common/Coroutines.kt
@@ -1,5 +1,6 @@
 package flow.common
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancelChildren
@@ -10,4 +11,12 @@ fun CoroutineScope.newCancelableScope() = CoroutineScope(coroutineContext + Supe
 fun CoroutineScope.relaunch(block: suspend CoroutineScope.() -> Unit) {
     coroutineContext.cancelChildren()
     launch(block = block)
+}
+
+inline fun <R> runSuspendCatching(block: () -> R): Result<R> = try {
+    Result.success(block())
+} catch (e: CancellationException) {
+    throw e
+} catch (e: Throwable) {
+    Result.failure(e)
 }

--- a/feature/account/src/main/kotlin/flow/account/AccountViewModel.kt
+++ b/feature/account/src/main/kotlin/flow/account/AccountViewModel.kt
@@ -22,7 +22,15 @@ internal class AccountViewModel @Inject constructor(
 
     override val container: Container<AuthState, AccountSideEffect> = container(
         initialState = AuthState.Unauthorized,
-        onCreate = { observeAuthState() },
+        onCreate = {
+            repeatOnSubscription {
+                logger.d { "Start observing auth state" }
+                observeAuthStateUseCase().collectLatest { authState ->
+                    logger.d { "On new auth state: $authState" }
+                    reduce { authState }
+                }
+            }
+        },
     )
 
     fun perform(action: AccountAction) {
@@ -31,14 +39,6 @@ internal class AccountViewModel @Inject constructor(
             AccountAction.ConfirmLogoutClick -> onConfirmLogoutClick()
             AccountAction.LoginClick -> onLoginClick()
             AccountAction.LogoutClick -> onLogoutClick()
-        }
-    }
-
-    private fun observeAuthState() = intent {
-        logger.d { "Start observing auth state" }
-        observeAuthStateUseCase().collectLatest { authState ->
-            logger.d { "On new auth state: $authState" }
-            reduce { authState }
         }
     }
 

--- a/feature/bookmarks/src/main/kotlin/flow/forum/bookmarks/BookmarksViewModel.kt
+++ b/feature/bookmarks/src/main/kotlin/flow/forum/bookmarks/BookmarksViewModel.kt
@@ -19,7 +19,21 @@ internal class BookmarksViewModel @Inject constructor(
 
     override val container: Container<BookmarksState, BookmarksSideEffect> = container(
         initialState = BookmarksState.Initial,
-        onCreate = { observeBookmarks() },
+        onCreate = {
+            repeatOnSubscription {
+                logger.d { "Start observing bookmarks" }
+                observeBookmarksUseCase().collectLatest { items ->
+                    reduce {
+                        logger.d { "On new bookmarks list: $items" }
+                        if (items.isEmpty()) {
+                            BookmarksState.Empty
+                        } else {
+                            BookmarksState.BookmarksList(items)
+                        }
+                    }
+                }
+            }
+        },
     )
 
     fun perform(action: BookmarksAction) {
@@ -27,20 +41,6 @@ internal class BookmarksViewModel @Inject constructor(
         when (action) {
             is BookmarksAction.BookmarkClicked -> intent {
                 postSideEffect(BookmarksSideEffect.OpenCategory(action.bookmark.category.id))
-            }
-        }
-    }
-
-    private fun observeBookmarks() = intent {
-        logger.d { "Start observing bookmarks" }
-        observeBookmarksUseCase().collectLatest { items ->
-            reduce {
-                logger.d { "On new bookmarks list: $items" }
-                if (items.isEmpty()) {
-                    BookmarksState.Empty
-                } else {
-                    BookmarksState.BookmarksList(items)
-                }
             }
         }
     }

--- a/feature/category/src/main/kotlin/flow/forum/category/CategoryViewModel.kt
+++ b/feature/category/src/main/kotlin/flow/forum/category/CategoryViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import flow.common.runSuspendCatching
 import flow.domain.model.PagingAction
 import flow.domain.model.append
 import flow.domain.model.category.CategoryPage
@@ -21,6 +22,7 @@ import flow.models.topic.Topic
 import flow.models.topic.TopicModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.viewmodel.container
@@ -43,9 +45,43 @@ internal class CategoryViewModel @Inject constructor(
     override val container: Container<CategoryPageState, CategorySideEffect> = container(
         initialState = CategoryPageState(),
         onCreate = {
-            observeAuthState()
-            observeCategoryModel()
-            observePagingData()
+            repeatOnSubscription {
+                launch {
+                    logger.d { "Start observing auth state" }
+                    authStateUseCase().collectLatest { authState ->
+                        reduce { state.copy(authState = authState) }
+                    }
+                }
+                launch {
+                    logger.d { "Start observing category model" }
+                    observeCategoryModelUseCase(categoryId).collectLatest { categoryModel ->
+                        val categoryState = CategoryState.Category(
+                            name = categoryModel.category.name,
+                            isBookmark = categoryModel.isBookmark,
+                        )
+                        reduce { state.copy(categoryState = categoryState) }
+                    }
+                }
+                launch {
+                    logger.d { "Start observing paging data" }
+                    observeCategoryPagingDataUseCase(
+                        id = categoryId,
+                        actionsFlow = pagingActions,
+                        scope = viewModelScope,
+                    ).collectLatest { (data, loadStates) ->
+                        reduce {
+                            state.copy(
+                                categoryContent = when {
+                                    data == null -> CategoryContent.Initial
+                                    data.isEmpty() -> CategoryContent.Empty
+                                    else -> data.toContent()
+                                },
+                                loadStates = loadStates,
+                            )
+                        }
+                    }
+                }
+            }
         },
     )
 
@@ -61,44 +97,6 @@ internal class CategoryViewModel @Inject constructor(
             is CategoryAction.RetryClick -> onRetryClick()
             is CategoryAction.SearchClick -> onSearchClick()
             is CategoryAction.TopicClick -> onTopicClick(action.topicModel)
-        }
-    }
-
-    private fun observeAuthState() = intent {
-        logger.d { "Start observing auth state" }
-        authStateUseCase().collectLatest { authState ->
-            reduce { state.copy(authState = authState) }
-        }
-    }
-
-    private fun observeCategoryModel() = intent {
-        logger.d { "Start observing category model" }
-        observeCategoryModelUseCase(categoryId).collectLatest { categoryModel ->
-            val categoryState = CategoryState.Category(
-                name = categoryModel.category.name,
-                isBookmark = categoryModel.isBookmark,
-            )
-            reduce { state.copy(categoryState = categoryState) }
-        }
-    }
-
-    private fun observePagingData() = intent {
-        logger.d { "Start observing paging data" }
-        observeCategoryPagingDataUseCase(
-            id = categoryId,
-            actionsFlow = pagingActions,
-            scope = viewModelScope,
-        ).collectLatest { (data, loadStates) ->
-            reduce {
-                state.copy(
-                    categoryContent = when {
-                        data == null -> CategoryContent.Initial
-                        data.isEmpty() -> CategoryContent.Empty
-                        else -> data.toContent()
-                    },
-                    loadStates = loadStates,
-                )
-            }
         }
     }
 
@@ -119,7 +117,7 @@ internal class CategoryViewModel @Inject constructor(
     }
 
     private fun onFavoriteClick(topicModel: TopicModel<out Topic>) = intent {
-        runCatching { toggleFavoriteUseCase(topicModel.topic.id) }
+        runSuspendCatching { toggleFavoriteUseCase(topicModel.topic.id) }
             .onFailure { postSideEffect(CategorySideEffect.ShowFavoriteToggleError) }
     }
 

--- a/feature/favorites/src/main/kotlin/flow/favorites/FavoritesViewModel.kt
+++ b/feature/favorites/src/main/kotlin/flow/favorites/FavoritesViewModel.kt
@@ -22,27 +22,27 @@ class FavoritesViewModel @Inject constructor(
 
     override val container: Container<FavoritesState, FavoritesSideEffect> = container(
         initialState = FavoritesState.Initial,
-        onCreate = { observeFavorites() },
+        onCreate = {
+            repeatOnSubscription {
+                logger.d { "Start observing favorites" }
+                observeFavoritesUseCase(viewModelScope).collectLatest { items ->
+                    logger.d { "On new favorites list: $items" }
+                    reduce {
+                        if (items.isEmpty()) {
+                            FavoritesState.Empty
+                        } else {
+                            FavoritesState.FavoritesList(items)
+                        }
+                    }
+                }
+            }
+        },
     )
 
     fun perform(action: FavoritesAction) {
         logger.d { "Perform $action" }
         when (action) {
             is FavoritesAction.TopicClick -> onTopicClick(action.topicModel)
-        }
-    }
-
-    private fun observeFavorites() = intent {
-        logger.d { "Start observing favorites" }
-        observeFavoritesUseCase(viewModelScope).collectLatest { items ->
-            logger.d { "On new favorites list: $items" }
-            reduce {
-                if (items.isEmpty()) {
-                    FavoritesState.Empty
-                } else {
-                    FavoritesState.FavoritesList(items)
-                }
-            }
         }
     }
 

--- a/feature/forum/src/main/kotlin/flow/forum/ForumViewModel.kt
+++ b/feature/forum/src/main/kotlin/flow/forum/ForumViewModel.kt
@@ -2,6 +2,7 @@ package flow.forum
 
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import flow.common.runSuspendCatching
 import flow.domain.usecase.GetForumUseCase
 import flow.logger.api.LoggerFactory
 import flow.models.forum.ForumCategory
@@ -35,7 +36,7 @@ internal class ForumViewModel @Inject constructor(
     private fun loadForum() = intent {
         logger.d { "Launch load forum" }
         reduce { ForumState.Loading }
-        runCatching { coroutineScope { getForumUseCase() } }
+        runSuspendCatching { coroutineScope { getForumUseCase() } }
             .onSuccess { forum ->
                 logger.d { "Forum loaded" }
                 reduce { ForumState.Loaded(forum.children.map(::Expandable)) }

--- a/feature/menu/src/main/kotlin/flow/menu/MenuViewModel.kt
+++ b/feature/menu/src/main/kotlin/flow/menu/MenuViewModel.kt
@@ -33,7 +33,21 @@ internal class MenuViewModel @Inject constructor(
 
     override val container: Container<MenuState, MenuSideEffect> = container(
         initialState = MenuState(),
-        onCreate = { observeSettings() },
+        onCreate = {
+            repeatOnSubscription {
+                logger.d { "Start observing settings" }
+                observeSettingsUseCase().collectLatest { settings ->
+                    reduce {
+                        logger.d { "On new settings: $settings" }
+                        MenuState(
+                            theme = settings.theme,
+                            favoritesSyncPeriod = settings.favoritesSyncPeriod,
+                            bookmarksSyncPeriod = settings.bookmarksSyncPeriod,
+                        )
+                    }
+                }
+            }
+        },
     )
 
     fun perform(action: MenuAction) {
@@ -51,20 +65,6 @@ internal class MenuViewModel @Inject constructor(
             is MenuAction.SetBookmarksSyncPeriod -> onSetBookmarksSyncPeriod(action.syncPeriod)
             is MenuAction.SetFavoritesSyncPeriod -> onSetFavoritesSyncPeriod(action.syncPeriod)
             is MenuAction.SetTheme -> onSetTheme(action.theme)
-        }
-    }
-
-    private fun observeSettings() = intent {
-        logger.d { "Start observing settings" }
-        observeSettingsUseCase().collectLatest { settings ->
-            reduce {
-                logger.d { "On new settings: $settings" }
-                MenuState(
-                    theme = settings.theme,
-                    favoritesSyncPeriod = settings.favoritesSyncPeriod,
-                    bookmarksSyncPeriod = settings.bookmarksSyncPeriod,
-                )
-            }
         }
     }
 

--- a/feature/rating/src/main/kotlin/flow/rating/RatingViewModel.kt
+++ b/feature/rating/src/main/kotlin/flow/rating/RatingViewModel.kt
@@ -29,8 +29,10 @@ class RatingViewModel @Inject constructor(
     override val container: Container<RatingRequest, RatingSideEffect> = container(
         initialState = RatingRequest.Hide,
         onCreate = {
-            observeRatingRequest()
-            intent { appLaunchedUseCase() }
+            appLaunchedUseCase()
+            repeatOnSubscription {
+                observeRatingRequestUseCase().collectLatest { reduce { it } }
+            }
         },
     )
 
@@ -42,10 +44,6 @@ class RatingViewModel @Inject constructor(
             is RatingAction.NeverAskAgainClick -> onNeverAskAgainClick()
             is RatingAction.RatingClick -> onRatingClick()
         }
-    }
-
-    private fun observeRatingRequest() = intent {
-        observeRatingRequestUseCase().collectLatest { reduce { it } }
     }
 
     private fun onAskLaterClick() = intent {

--- a/feature/search/src/main/kotlin/flow/search/SearchViewModel.kt
+++ b/feature/search/src/main/kotlin/flow/search/SearchViewModel.kt
@@ -1,7 +1,6 @@
 package flow.search
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import flow.domain.model.search.isEmpty
 import flow.domain.usecase.ObserveAuthStateUseCase
@@ -13,7 +12,6 @@ import flow.logger.api.LoggerFactory
 import flow.models.auth.isAuthorized
 import flow.models.search.Search
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.viewmodel.container
@@ -32,7 +30,29 @@ internal class SearchViewModel @Inject constructor(
 
     override val container: Container<SearchState, SearchSideEffect> = container(
         initialState = SearchState.Initial,
-        onCreate = { observeSearchHistory() },
+        onCreate = {
+            repeatOnSubscription {
+                logger.d { "Start observing search history" }
+                observeAuthStateUseCase().collectLatest { authState ->
+                    if (authState.isAuthorized) {
+                        observeSearchHistoryUseCase().collectLatest { searchHistory ->
+                            reduce {
+                                if (searchHistory.isEmpty()) {
+                                    SearchState.Empty
+                                } else {
+                                    SearchState.SearchList(
+                                        pinned = searchHistory.pinned,
+                                        other = searchHistory.other,
+                                    )
+                                }
+                            }
+                        }
+                    } else {
+                        reduce { SearchState.Unauthorised }
+                    }
+                }
+            }
+        },
     )
 
     fun perform(action: SearchAction) {
@@ -47,38 +67,16 @@ internal class SearchViewModel @Inject constructor(
         }
     }
 
-    private fun observeSearchHistory() = intent {
-        logger.d { "Start observing search history" }
-        observeAuthStateUseCase().collectLatest { authState ->
-            if (authState.isAuthorized) {
-                observeSearchHistoryUseCase().collectLatest { searchHistory ->
-                    reduce {
-                        if (searchHistory.isEmpty()) {
-                            SearchState.Empty
-                        } else {
-                            SearchState.SearchList(
-                                pinned = searchHistory.pinned,
-                                other = searchHistory.other,
-                            )
-                        }
-                    }
-                }
-            } else {
-                reduce { SearchState.Unauthorised }
-            }
-        }
-    }
-
-    private fun onDeleteItemClick(search: Search) = viewModelScope.launch {
-        removeSearchHistoryUseCase.invoke(search)
+    private fun onDeleteItemClick(search: Search) = intent {
+        removeSearchHistoryUseCase(search)
     }
 
     private fun onLoginClick() = intent {
         postSideEffect(SearchSideEffect.OpenLogin)
     }
 
-    private fun onPinItemClick(search: Search) = viewModelScope.launch {
-        pinSearchHistoryUseCase.invoke(search)
+    private fun onPinItemClick(search: Search) = intent {
+        pinSearchHistoryUseCase(search)
     }
 
     private fun onSearchActionClick() = intent {
@@ -89,7 +87,7 @@ internal class SearchViewModel @Inject constructor(
         postSideEffect(SearchSideEffect.OpenSearch(search.filter))
     }
 
-    private fun onUnpinItemClick(search: Search) = viewModelScope.launch {
-        unpinSearchHistoryUseCase.invoke(search)
+    private fun onUnpinItemClick(search: Search) = intent {
+        unpinSearchHistoryUseCase(search)
     }
 }

--- a/feature/search_result/src/main/kotlin/flow/search/result/SearchResultViewModel.kt
+++ b/feature/search_result/src/main/kotlin/flow/search/result/SearchResultViewModel.kt
@@ -14,6 +14,7 @@ import flow.domain.usecase.ObserveSearchPagingDataUseCase
 import flow.domain.usecase.ToggleFavoriteUseCase
 import flow.logger.api.LoggerFactory
 import flow.models.forum.Category
+import flow.models.search.Filter
 import flow.models.search.Order
 import flow.models.search.Period
 import flow.models.search.Sort
@@ -23,7 +24,6 @@ import flow.models.topic.TopicModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.ContainerHost
@@ -46,14 +46,14 @@ internal class SearchResultViewModel @Inject constructor(
     override val container: Container<SearchPageState, SearchResultSideEffect> = container(
         initialState = SearchPageState(mutableFilter.value),
         onCreate = {
-            mutableFilter.emit(enrichFilterUseCase(state.filter))
+            val enriched = enrichFilterUseCase(state.filter)
+            mutableFilter.emit(enriched)
+            addSearchHistoryUseCase(enriched)
             repeatOnSubscription {
                 launch {
-                    mutableFilter
-                        .onEach(addSearchHistoryUseCase::invoke)
-                        .collectLatest { filter ->
-                            reduce { state.copy(filter = filter) }
-                        }
+                    mutableFilter.collectLatest { filter ->
+                        reduce { state.copy(filter = filter) }
+                    }
                 }
                 launch {
                     logger.d { "Start observing paging data" }
@@ -126,21 +126,27 @@ internal class SearchResultViewModel @Inject constructor(
     }
 
     private fun onSetAuthor(author: Author?) = intent {
-        mutableFilter.emit(mutableFilter.value.copy(author = author))
+        updateFilter { copy(author = author) }
         reduce { state.copy(appBarExpanded = false) }
     }
 
     private fun onSetCategories(categories: List<Category>?) = intent {
-        mutableFilter.emit(mutableFilter.value.copy(categories = categories))
+        updateFilter { copy(categories = categories) }
         reduce { state.copy(appBarExpanded = false) }
     }
 
     private fun onSetSort(sort: Sort) = intent {
-        mutableFilter.emit(mutableFilter.value.copy(sort = sort))
+        updateFilter { copy(sort = sort) }
     }
 
     private fun onSetOrder(order: Order) = intent {
-        mutableFilter.emit(mutableFilter.value.copy(order = order))
+        updateFilter { copy(order = order) }
+    }
+
+    private suspend fun updateFilter(transform: Filter.() -> Filter) {
+        val updated = mutableFilter.value.transform()
+        mutableFilter.emit(updated)
+        addSearchHistoryUseCase(updated)
     }
 
     private fun onSetPeriod(period: Period) = intent {

--- a/feature/search_result/src/main/kotlin/flow/search/result/SearchResultViewModel.kt
+++ b/feature/search_result/src/main/kotlin/flow/search/result/SearchResultViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import flow.common.runSuspendCatching
 import flow.domain.model.PagingAction
 import flow.domain.model.append
 import flow.domain.model.retry
@@ -23,6 +24,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.viewmodel.container
@@ -44,8 +46,38 @@ internal class SearchResultViewModel @Inject constructor(
     override val container: Container<SearchPageState, SearchResultSideEffect> = container(
         initialState = SearchPageState(mutableFilter.value),
         onCreate = {
-            observeFilter()
-            observePagingData()
+            mutableFilter.emit(enrichFilterUseCase(state.filter))
+            repeatOnSubscription {
+                launch {
+                    mutableFilter
+                        .onEach(addSearchHistoryUseCase::invoke)
+                        .collectLatest { filter ->
+                            reduce { state.copy(filter = filter) }
+                        }
+                }
+                launch {
+                    logger.d { "Start observing paging data" }
+                    observeSearchPagingDataUseCase(
+                        filterFlow = mutableFilter,
+                        actionsFlow = pagingActions,
+                        scope = viewModelScope,
+                    ).collectLatest { (data, loadingState) ->
+                        reduce {
+                            state.copy(
+                                searchContent = when {
+                                    data == null -> SearchResultContent.Initial
+                                    data.isEmpty() -> SearchResultContent.Empty
+                                    else -> SearchResultContent.Content(
+                                        torrents = data,
+                                        categories = data.mapNotNull { it.topic.category }.distinct(),
+                                    )
+                                },
+                                loadStates = loadingState,
+                            )
+                        }
+                    }
+                }
+            }
         },
     )
 
@@ -67,38 +99,6 @@ internal class SearchResultViewModel @Inject constructor(
         }
     }
 
-    private fun observeFilter() = intent {
-        mutableFilter.emit(enrichFilterUseCase(state.filter))
-        mutableFilter
-            .onEach(addSearchHistoryUseCase::invoke)
-            .collectLatest { filter ->
-                reduce { state.copy(filter = filter) }
-            }
-    }
-
-    private fun observePagingData() = intent {
-        logger.d { "Start observing paging data" }
-        observeSearchPagingDataUseCase(
-            filterFlow = mutableFilter,
-            actionsFlow = pagingActions,
-            scope = viewModelScope,
-        ).collectLatest { (data, loadingState) ->
-            reduce {
-                state.copy(
-                    searchContent = when {
-                        data == null -> SearchResultContent.Initial
-                        data.isEmpty() -> SearchResultContent.Empty
-                        else -> SearchResultContent.Content(
-                            torrents = data,
-                            categories = data.mapNotNull { it.topic.category }.distinct(),
-                        )
-                    },
-                    loadStates = loadingState,
-                )
-            }
-        }
-    }
-
     private fun onBackClick() = intent {
         postSideEffect(SearchResultSideEffect.Back)
     }
@@ -108,7 +108,7 @@ internal class SearchResultViewModel @Inject constructor(
     }
 
     private fun onFavoriteClick(topicModel: TopicModel<out Topic>) = intent {
-        runCatching { toggleFavoriteUseCase(topicModel.topic.id) }
+        runSuspendCatching { toggleFavoriteUseCase(topicModel.topic.id) }
             .onFailure { postSideEffect(SearchResultSideEffect.ShowFavoriteToggleError) }
     }
 

--- a/feature/search_result/src/main/kotlin/flow/search/result/categories/CategorySelectionViewModel.kt
+++ b/feature/search_result/src/main/kotlin/flow/search/result/categories/CategorySelectionViewModel.kt
@@ -2,6 +2,7 @@ package flow.search.result.categories
 
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import flow.common.runSuspendCatching
 import flow.logger.api.LoggerFactory
 import flow.models.forum.Category
 import flow.search.result.categories.CategorySelectionAction.ExpandClick
@@ -49,7 +50,7 @@ internal class CategorySelectionViewModel @Inject constructor(
     }
 
     private fun loadForumTree() = intent {
-        runCatching {
+        runSuspendCatching {
             coroutineScope {
                 getFlattenForumTreeUseCase.invoke(expandedIds, selectedIds)
             }
@@ -64,7 +65,7 @@ internal class CategorySelectionViewModel @Inject constructor(
     }
 
     private fun onExpandClick(item: ForumTreeItem) = intent {
-        runCatching {
+        runSuspendCatching {
             coroutineScope {
                 if (expandedIds.contains(item.id)) {
                     expandedIds.remove(item.id)
@@ -78,7 +79,7 @@ internal class CategorySelectionViewModel @Inject constructor(
     }
 
     private fun onSelectClick(item: ForumTreeItem) = intent {
-        runCatching {
+        runSuspendCatching {
             coroutineScope {
                 val id = item.id
                 val updatedCategories = when (item) {

--- a/feature/topic/src/main/kotlin/flow/topic/TopicViewModel.kt
+++ b/feature/topic/src/main/kotlin/flow/topic/TopicViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import flow.common.runSuspendCatching
 import flow.domain.model.PagingAction
 import flow.domain.model.refresh
 import flow.domain.model.retry
@@ -21,6 +22,7 @@ import flow.models.topic.Author
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.viewmodel.container
@@ -46,8 +48,40 @@ internal class TopicViewModel @Inject constructor(
         initialState = TopicState(),
         onCreate = {
             loadTopic()
-            observePagingData()
-            observeFavoritesState()
+            repeatOnSubscription {
+                launch {
+                    observeTopicPagingDataUseCase(
+                        id = id,
+                        actions = pagingActions,
+                        scope = viewModelScope,
+                    ).collectLatest { (data, loadStates, pagination) ->
+                        reduce {
+                            state.copy(
+                                paginationState = if (pagination.totalPages > 1) {
+                                    PaginationState.Pagination(
+                                        page = pagination.loadedPages.first,
+                                        totalPages = pagination.totalPages,
+                                    )
+                                } else {
+                                    PaginationState.NoPagination
+                                },
+                                commentsContent = when {
+                                    data == null -> CommentsContent.Initial
+                                    data.isEmpty() -> CommentsContent.Empty
+                                    else -> CommentsContent.Posts(data)
+                                },
+                                loadStates = loadStates,
+                            )
+                        }
+                    }
+                }
+                launch {
+                    observeFavoriteStateUseCase(id).collectLatest { isFavorite ->
+                        val favoriteState = TopicFavoriteState.FavoriteState(isFavorite)
+                        reduce { state.copy(favoriteState = favoriteState) }
+                    }
+                }
+            }
         },
     )
 
@@ -71,7 +105,7 @@ internal class TopicViewModel @Inject constructor(
     }
 
     private fun loadTopic() = intent {
-        runCatching { coroutineScope { getTopicUseCase(id) } }
+        runSuspendCatching { coroutineScope { getTopicUseCase(id) } }
             .onSuccess { topic ->
                 reduce {
                     val torrentData = topic.torrentData
@@ -87,41 +121,7 @@ internal class TopicViewModel @Inject constructor(
                     )
                 }
             }
-            .onFailure { }
-    }
-
-    private fun observeFavoritesState() = intent {
-        observeFavoriteStateUseCase(id).collectLatest { isFavorite ->
-            val favoriteState = TopicFavoriteState.FavoriteState(isFavorite)
-            reduce { state.copy(favoriteState = favoriteState) }
-        }
-    }
-
-    private fun observePagingData() = intent {
-        observeTopicPagingDataUseCase(
-            id = id,
-            actions = pagingActions,
-            scope = viewModelScope,
-        ).collectLatest { (data, loadStates, pagination) ->
-            reduce {
-                state.copy(
-                    paginationState = if (pagination.totalPages > 1) {
-                        PaginationState.Pagination(
-                            page = pagination.loadedPages.first,
-                            totalPages = pagination.totalPages,
-                        )
-                    } else {
-                        PaginationState.NoPagination
-                    },
-                    commentsContent = when {
-                        data == null -> CommentsContent.Initial
-                        data.isEmpty() -> CommentsContent.Empty
-                        else -> CommentsContent.Posts(data)
-                    },
-                    loadStates = loadStates,
-                )
-            }
-        }
+            .onFailure { error -> logger.e(error) { "Topic load error" } }
     }
 
     private fun onAddComment(comment: String) = intent {
@@ -145,7 +145,7 @@ internal class TopicViewModel @Inject constructor(
     }
 
     private fun onFavoriteClick() = intent {
-        runCatching { toggleFavoriteUseCase(id) }
+        runSuspendCatching { toggleFavoriteUseCase(id) }
             .onFailure { postSideEffect(TopicSideEffect.ShowFavoriteToggleError) }
     }
 
@@ -184,12 +184,12 @@ internal class TopicViewModel @Inject constructor(
             reduce { state.copy(downloadState = DownloadState.Started) }
             val uri = downloadTorrentUseCase(id, title)
             if (uri != null) {
-                intent { reduce { state.copy(downloadState = DownloadState.Completed(uri)) } }
+                reduce { state.copy(downloadState = DownloadState.Completed(uri)) }
             } else {
-                intent { reduce { state.copy(downloadState = DownloadState.Error) } }
+                reduce { state.copy(downloadState = DownloadState.Error) }
             }
         } else {
-            intent { postSideEffect(TopicSideEffect.ShowLoginRequired) }
+            postSideEffect(TopicSideEffect.ShowLoginRequired)
         }
     }
 

--- a/feature/visited/src/main/kotlin/flow/visited/VisitedViewModel.kt
+++ b/feature/visited/src/main/kotlin/flow/visited/VisitedViewModel.kt
@@ -2,6 +2,7 @@ package flow.visited
 
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import flow.common.runSuspendCatching
 import flow.domain.usecase.ObserveVisitedUseCase
 import flow.domain.usecase.ToggleFavoriteUseCase
 import flow.logger.api.LoggerFactory
@@ -23,7 +24,21 @@ internal class VisitedViewModel @Inject constructor(
 
     override val container: Container<VisitedState, VisitedSideEffect> = container(
         initialState = VisitedState.Initial,
-        onCreate = { observeVisited() },
+        onCreate = {
+            repeatOnSubscription {
+                logger.d { "Start observing visited" }
+                observeVisitedUseCase().collectLatest { items ->
+                    logger.d { "On new visited list: $items" }
+                    reduce {
+                        if (items.isEmpty()) {
+                            VisitedState.Empty
+                        } else {
+                            VisitedState.VisitedList(items)
+                        }
+                    }
+                }
+            }
+        },
     )
 
     fun perform(action: VisitedAction) {
@@ -34,22 +49,8 @@ internal class VisitedViewModel @Inject constructor(
         }
     }
 
-    private fun observeVisited() = intent {
-        logger.d { "Start observing visited" }
-        observeVisitedUseCase().collectLatest { items ->
-            logger.d { "On new visited list: $items" }
-            reduce {
-                if (items.isEmpty()) {
-                    VisitedState.Empty
-                } else {
-                    VisitedState.VisitedList(items)
-                }
-            }
-        }
-    }
-
     private fun onFavoriteClick(topicModel: TopicModel<out Topic>) = intent {
-        runCatching { toggleFavoriteUseCase(topicModel.topic.id) }
+        runSuspendCatching { toggleFavoriteUseCase(topicModel.topic.id) }
             .onFailure { postSideEffect(VisitedSideEffect.ShowFavoriteToggleError) }
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #47. Addresses the Orbit-usage findings from the post-migration review.

### Fixes

- **`runCatching` → `runSuspendCatching`** (high-priority). The stdlib `runCatching` swallows `CancellationException`, breaking structured concurrency: if a container or intent is cancelled while a use-case runs inside it, the cancellation is lost and the coroutine survives. Replaced in all 8 ViewModel usages with a new `runSuspendCatching` helper in `core/common/Coroutines.kt` that rethrows cancellation.
- **`repeatOnSubscription` for repository observers** (medium-priority). Per Orbit v10 guidance, hot flows should be collected only while there are subscribers. Previously the observers in `onCreate` collected forever, even with the UI gone. Wrapped the observers in `AccountViewModel`, `BookmarksViewModel`, `CategoryViewModel`, `FavoritesViewModel`, `MenuViewModel`, `RatingViewModel`, `SearchViewModel`, `SearchResultViewModel`, `TopicViewModel`, `VisitedViewModel`.
- **`viewModelScope.launch` → `intent` in `SearchViewModel`** (medium-priority). `onDeleteItemClick`/`onPinItemClick`/`onUnpinItemClick` now go through the container instead of bypassing it.
- **Flatten nested `intent` in `TopicViewModel.onTorrentFileClick`** (low-priority). Removed `intent { reduce {} }` / `intent { postSideEffect() }` wrappers inside the outer `intent { }`.
- **Drop redundant `intent` in `RatingViewModel.onCreate`** (low-priority). `appLaunchedUseCase()` is now called directly from the `Syntax`-receiver lambda.
- **Surface Topic load failure** (high-priority). `TopicViewModel.loadTopic` no longer ignores errors — they are logged via `logger.e`.

### Not changed (deferred)

- `SearchInputViewModel`'s custom `newCancelableScope`/`relaunch` — architectural refactor; safe but out of scope.
- `ForumState`/`runOn<T>` — optional cosmetic refactor.
- Auto-saved state via `SavedStateHandle` + KSerializer — design decision; deferred.

### Verification

`./gradlew compileDebugKotlin` for all 13 Orbit-using feature modules + `:core:common` builds green (only the unrelated `processDebugGoogleServices` task fails due to missing `google-services.json` locally, as before).

## Test plan

- [ ] CI build passes.
- [ ] Smoke test every screen backed by an Orbit ViewModel — state still hydrates, side effects (snackbars, navigation) still fire, action handlers (favorite, pin/unpin search, etc.) still work.
- [ ] Verify that hidden screens stop emitting reducer updates (subscription-aware behavior).

https://claude.ai/code/session_01XoEAxPGWsJo8eFGreULCsw

---
_Generated by [Claude Code](https://claude.ai/code/session_01XoEAxPGWsJo8eFGreULCsw)_