### PR TITLE
Replace jsoup with ksoup for HTML parsing

### DIFF
--- a/core/network/rutracker/build.gradle.kts
+++ b/core/network/rutracker/build.gradle.kts
@@ -6,5 +6,5 @@ dependencies {
     api(project(":core:network:api"))
 
     implementation(libs.ktor.client.core)
-    implementation(libs.jsoup)
+    implementation(libs.ksoup)
 }

--- a/core/network/rutracker/src/main/kotlin/flow/network/domain/GetCategoryPageUseCase.kt
+++ b/core/network/rutracker/src/main/kotlin/flow/network/domain/GetCategoryPageUseCase.kt
@@ -1,5 +1,6 @@
 package flow.network.domain
 
+import com.fleeksoft.ksoup.Ksoup
 import flow.network.api.RuTrackerInnerApi
 import flow.network.dto.forum.CategoryDto
 import flow.network.dto.forum.CategoryPageDto
@@ -10,7 +11,6 @@ import flow.network.dto.topic.TopicDto
 import flow.network.dto.topic.TorrentDto
 import flow.network.model.Forbidden
 import flow.network.model.NotFound
-import org.jsoup.Jsoup
 
 internal class GetCategoryPageUseCase(private val api: RuTrackerInnerApi) {
 
@@ -35,7 +35,7 @@ internal class GetCategoryPageUseCase(private val api: RuTrackerInnerApi) {
         }
 
         private fun parseCategoryPage(html: String, forumId: String): CategoryPageDto {
-            val doc = Jsoup.parse(html)
+            val doc = Ksoup.parse(html)
             val currentPage = doc.select("#pagination > p:nth-child(1) > b:nth-child(1)").toInt(1)
             val totalPages = doc.select("#pagination > p:nth-child(1) > b:nth-child(2)").toInt(1)
             val forumName = doc.select(".maintitle").toStr()

--- a/core/network/rutracker/src/main/kotlin/flow/network/domain/GetCurrentProfileUseCase.kt
+++ b/core/network/rutracker/src/main/kotlin/flow/network/domain/GetCurrentProfileUseCase.kt
@@ -1,8 +1,8 @@
 package flow.network.domain
 
+import com.fleeksoft.ksoup.Ksoup
 import flow.network.api.RuTrackerInnerApi
 import flow.network.dto.user.ProfileDto
-import org.jsoup.Jsoup
 
 internal class GetCurrentProfileUseCase(
     private val api: RuTrackerInnerApi,
@@ -14,7 +14,7 @@ internal class GetCurrentProfileUseCase(
 
     companion object {
         private fun parseUserId(html: String): String {
-            return Jsoup.parse(html)
+            return Ksoup.parse(html)
                 .select("#logged-in-username")
                 .queryParam("u")
         }

--- a/core/network/rutracker/src/main/kotlin/flow/network/domain/GetFavoritesUseCase.kt
+++ b/core/network/rutracker/src/main/kotlin/flow/network/domain/GetFavoritesUseCase.kt
@@ -1,5 +1,6 @@
 package flow.network.domain
 
+import com.fleeksoft.ksoup.Ksoup
 import flow.network.api.RuTrackerInnerApi
 import flow.network.dto.forum.CategoryDto
 import flow.network.dto.topic.AuthorDto
@@ -7,7 +8,6 @@ import flow.network.dto.topic.ForumTopicDto
 import flow.network.dto.topic.TopicDto
 import flow.network.dto.topic.TorrentDto
 import flow.network.dto.user.FavoritesDto
-import org.jsoup.Jsoup
 
 internal class GetFavoritesUseCase(
     private val api: RuTrackerInnerApi,
@@ -34,7 +34,7 @@ internal class GetFavoritesUseCase(
 
     companion object {
         private fun parsePagesCount(html: String): Int {
-            val doc = Jsoup.parse(html)
+            val doc = Ksoup.parse(html)
             val navigation = doc.select("#pagination")
             val currentPage = navigation.select("b").toInt(1)
             return maxOf(
@@ -48,7 +48,7 @@ internal class GetFavoritesUseCase(
         }
 
         private fun parseFavorites(html: String): List<ForumTopicDto> {
-            return Jsoup
+            return Ksoup
                 .parse(html)
                 .select(".hl-tr")
                 .map { element ->

--- a/core/network/rutracker/src/main/kotlin/flow/network/domain/GetForumUseCase.kt
+++ b/core/network/rutracker/src/main/kotlin/flow/network/domain/GetForumUseCase.kt
@@ -1,9 +1,9 @@
 package flow.network.domain
 
+import com.fleeksoft.ksoup.Ksoup
 import flow.network.api.RuTrackerInnerApi
 import flow.network.dto.forum.CategoryDto
 import flow.network.dto.forum.ForumDto
-import org.jsoup.Jsoup
 
 internal class GetForumUseCase(private val api: RuTrackerInnerApi) {
 
@@ -16,7 +16,7 @@ internal class GetForumUseCase(private val api: RuTrackerInnerApi) {
 
     companion object {
         private fun parseForumTree(html: String): ForumDto {
-            val doc = Jsoup.parse(html)
+            val doc = Ksoup.parse(html)
             val categories = mutableListOf<CategoryDto>()
             val treeRoots = doc.select(".tree-root")
             treeRoots.forEach { categoryElement ->

--- a/core/network/rutracker/src/main/kotlin/flow/network/domain/GetProfileUseCase.kt
+++ b/core/network/rutracker/src/main/kotlin/flow/network/domain/GetProfileUseCase.kt
@@ -1,8 +1,8 @@
 package flow.network.domain
 
+import com.fleeksoft.ksoup.Ksoup
 import flow.network.api.RuTrackerInnerApi
 import flow.network.dto.user.ProfileDto
-import org.jsoup.Jsoup
 
 internal class GetProfileUseCase(private val api: RuTrackerInnerApi) {
 
@@ -12,7 +12,7 @@ internal class GetProfileUseCase(private val api: RuTrackerInnerApi) {
 
     companion object {
         private fun parseProfile(html: String): ProfileDto {
-            val doc = Jsoup.parse(html)
+            val doc = Ksoup.parse(html)
             return ProfileDto(
                 id = doc.select("#profile-uname").attr("data-uid"),
                 name = doc.select("#profile-uname").toStr(),

--- a/core/network/rutracker/src/main/kotlin/flow/network/domain/GetSearchPageUseCase.kt
+++ b/core/network/rutracker/src/main/kotlin/flow/network/domain/GetSearchPageUseCase.kt
@@ -1,5 +1,6 @@
 package flow.network.domain
 
+import com.fleeksoft.ksoup.Ksoup
 import flow.network.api.RuTrackerInnerApi
 import flow.network.dto.forum.CategoryDto
 import flow.network.dto.search.SearchPageDto
@@ -9,7 +10,6 @@ import flow.network.dto.search.SearchSortTypeDto
 import flow.network.dto.topic.AuthorDto
 import flow.network.dto.topic.TorrentDto
 import flow.network.dto.topic.TorrentStatusDto
-import org.jsoup.Jsoup
 
 internal class GetSearchPageUseCase(
     private val api: RuTrackerInnerApi,
@@ -48,7 +48,7 @@ internal class GetSearchPageUseCase(
 
     companion object {
         fun parseSearchPage(html: String): SearchPageDto {
-            val doc = Jsoup.parse(html)
+            val doc = Ksoup.parse(html)
             val navigation =
                 doc.select("#main_content_wrap > div.bottom_info > div.nav > p:nth-child(1)")
             val currentPage = navigation.select("b:nth-child(1)").toInt(1)

--- a/core/network/rutracker/src/main/kotlin/flow/network/domain/ParseCommentsPageUseCase.kt
+++ b/core/network/rutracker/src/main/kotlin/flow/network/domain/ParseCommentsPageUseCase.kt
@@ -1,14 +1,14 @@
 package flow.network.domain
 
+import com.fleeksoft.ksoup.Ksoup
 import flow.network.dto.forum.CategoryDto
 import flow.network.dto.topic.AuthorDto
 import flow.network.dto.topic.CommentsPageDto
 import flow.network.dto.topic.PostDto
-import org.jsoup.Jsoup
 
 internal object ParseCommentsPageUseCase {
     operator fun invoke(html: String): CommentsPageDto {
-        val doc = Jsoup.parse(html)
+        val doc = Ksoup.parse(html)
         val id = doc.select("#topic-title").queryParam("t")
         val title = doc.select("#topic-title").toStr()
         val categoryNode = doc.select(".nav.w100.pad_2").select("a")

--- a/core/network/rutracker/src/main/kotlin/flow/network/domain/ParsePostUseCase.kt
+++ b/core/network/rutracker/src/main/kotlin/flow/network/domain/ParsePostUseCase.kt
@@ -1,5 +1,9 @@
 package flow.network.domain
 
+import com.fleeksoft.ksoup.nodes.Element
+import com.fleeksoft.ksoup.nodes.Node
+import com.fleeksoft.ksoup.nodes.TextNode
+import com.fleeksoft.ksoup.select.Elements
 import flow.network.dto.topic.Align
 import flow.network.dto.topic.Alignment
 import flow.network.dto.topic.Bold
@@ -23,10 +27,6 @@ import flow.network.dto.topic.Text
 import flow.network.dto.topic.TextAlignment
 import flow.network.dto.topic.UList
 import flow.network.dto.topic.Underscore
-import org.jsoup.nodes.Element
-import org.jsoup.nodes.Node
-import org.jsoup.nodes.TextNode
-import org.jsoup.select.Elements
 import java.util.Locale
 
 private typealias ElementsList = MutableList<PostElementDto>
@@ -104,13 +104,13 @@ internal object ParsePostUseCase {
                     appendElement(node.selectFirst(".q"))
                 }
 
-                node.hasClass("post-hr") || node.tag().name == "hr" -> hr()
+                node.hasClass("post-hr") || node.tag().name() == "hr" -> hr()
                 node.hasClass("post-br") -> postBr()
-                node.tag().name == "br" -> br()
+                node.tag().name() == "br" -> br()
                 else -> appendElement(node)
             }
 
-            is TextNode -> text(node.wholeText)
+            is TextNode -> text(node.getWholeText())
         }
     }
 

--- a/core/network/rutracker/src/main/kotlin/flow/network/domain/ParseTopicPageUseCase.kt
+++ b/core/network/rutracker/src/main/kotlin/flow/network/domain/ParseTopicPageUseCase.kt
@@ -1,17 +1,17 @@
 package flow.network.domain
 
+import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.nodes.Document
+import com.fleeksoft.ksoup.nodes.Element
 import flow.network.dto.forum.CategoryDto
 import flow.network.dto.topic.AuthorDto
 import flow.network.dto.topic.PostDto
 import flow.network.dto.topic.TopicPageCommentsDto
 import flow.network.dto.topic.TopicPageDto
 import flow.network.dto.topic.TorrentDataDto
-import org.jsoup.Jsoup
-import org.jsoup.nodes.Document
-import org.jsoup.nodes.Element
 
 internal object ParseTopicPageUseCase {
-    operator fun invoke(html: String) = Jsoup.parse(html).let { doc ->
+    operator fun invoke(html: String) = Ksoup.parse(html).let { doc ->
         TopicPageDto(
             id = doc.parseId(),
             title = doc.parseTitle(),

--- a/core/network/rutracker/src/main/kotlin/flow/network/domain/ParseTorrentStatusUseCase.kt
+++ b/core/network/rutracker/src/main/kotlin/flow/network/domain/ParseTorrentStatusUseCase.kt
@@ -1,7 +1,7 @@
 package flow.network.domain
 
+import com.fleeksoft.ksoup.nodes.Element
 import flow.network.dto.topic.TorrentStatusDto
-import org.jsoup.nodes.Element
 
 internal object ParseTorrentStatusUseCase {
     operator fun invoke(element: Element?): TorrentStatusDto? {

--- a/core/network/rutracker/src/main/kotlin/flow/network/domain/ParseTorrentUseCase.kt
+++ b/core/network/rutracker/src/main/kotlin/flow/network/domain/ParseTorrentUseCase.kt
@@ -1,14 +1,14 @@
 package flow.network.domain
 
+import com.fleeksoft.ksoup.Ksoup
 import flow.network.dto.forum.CategoryDto
 import flow.network.dto.topic.AuthorDto
 import flow.network.dto.topic.TorrentDescriptionDto
 import flow.network.dto.topic.TorrentDto
-import org.jsoup.Jsoup
 
 internal object ParseTorrentUseCase {
     operator fun invoke(html: String): TorrentDto {
-        val doc = Jsoup.parse(html)
+        val doc = Ksoup.parse(html)
         val id = doc.select("#topic-title").queryParam("t")
         val author = doc.select(".nick").first()?.text()?.let {
             val authorId = doc.select(".poster_btn").select(".txtb").first().queryParamOrNull("u")
@@ -45,7 +45,7 @@ internal object ParseTorrentUseCase {
     }
 
     private fun parseTorrentDescription(html: String): TorrentDescriptionDto {
-        val doc = Jsoup.parse(html)
+        val doc = Ksoup.parse(html)
         return try {
             val firstPost = doc.select("tbody[id^=post]").first()?.select(".post_body")
             TorrentDescriptionDto(ParsePostUseCase(firstPost))

--- a/core/network/rutracker/src/main/kotlin/flow/network/domain/Utils.kt
+++ b/core/network/rutracker/src/main/kotlin/flow/network/domain/Utils.kt
@@ -1,7 +1,7 @@
 package flow.network.domain
 
-import org.jsoup.nodes.Element
-import org.jsoup.select.Elements
+import com.fleeksoft.ksoup.nodes.Element
+import com.fleeksoft.ksoup.select.Elements
 import java.net.URI
 import java.util.regex.Pattern
 import kotlin.math.ln

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,7 @@ firebaseCrashlyticsGradlePlugin = "3.0.7"
 googleServicesGradlePlugin = "4.4.4"
 hilt = "2.59.2"
 hiltExt = "1.2.0"
-jsoup = "1.22.2"
+ksoup = "0.2.6"
 junit4 = "4.13.2"
 koin = "4.2.1"
 kotlin = "2.3.21"
@@ -84,7 +84,7 @@ hilt-dagger-compiler = { group = "com.google.dagger", name = "dagger-compiler", 
 hilt-work = { group = "androidx.hilt", name = "hilt-work", version.ref = "hiltExt" }
 javax-inject = { group = "javax.inject", name = "javax.inject", version = "1" }
 json = { group = "org.json", name = "json", version = "20220924" }
-jsoup = { group = "org.jsoup", name = "jsoup", version.ref = "jsoup" }
+ksoup = { group = "com.fleeksoft.ksoup", name = "ksoup", version.ref = "ksoup" }
 junit4 = { group = "junit", name = "junit", version.ref = "junit4" }
 koin = { group = "io.insert-koin", name = "koin-core", version.ref = "koin" }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinxCoroutines" }

--- a/proxy/build.gradle.kts
+++ b/proxy/build.gradle.kts
@@ -25,7 +25,7 @@ kotlin {
 
 dependencies {
     implementation(libs.bundles.ktor)
-    implementation(libs.jsoup)
+    implementation(libs.ksoup)
     implementation(libs.koin)
     implementation(project(":core:network:rutracker"))
 }


### PR DESCRIPTION
## Summary

Replaces **jsoup** with **ksoup** (`com.fleeksoft.ksoup`), a Kotlin Multiplatform port of jsoup, and removes jsoup entirely from the project.

## Changes

- **Version catalog** (`gradle/libs.versions.toml`): drop `jsoup 1.22.2`, add `ksoup 0.2.6`.
- **Dependencies**: switch `libs.jsoup` → `libs.ksoup` in `:core:network:rutracker` and `:proxy`.
- **Source** (`:core:network:rutracker` parsers, 12 files):
  - `org.jsoup.*` → `com.fleeksoft.ksoup.*` imports.
  - `Jsoup.parse(...)` → `Ksoup.parse(...)`.
  - Two small API differences adapted in `ParsePostUseCase`:
    - `Tag.name` (property) → `Tag.name()` (function)
    - `TextNode.wholeText` (property) → `TextNode.getWholeText()` (function)

The rest of the jsoup API (`select`, `selectFirst`, `first`/`last`, `attr`, `text`, `hasClass`, `children`, `childNodes`, `remove`, …) is identical in ksoup, so the parsing logic is otherwise untouched.

## Behaviour compatibility

The main risk in this swap is `Elements.first()` / `last()`: the parsers rely on jsoup's **null-on-empty** semantics (rather than Kotlin's `List.first()`, which throws). Verified that ksoup's `Nodes` declares its own `first()`/`last()` members returning a nullable `Element?` (bytecode shows `return null` when empty), so behaviour is preserved.

## Local verification

- `./gradlew :core:network:rutracker:compileKotlin` — ✅ compiles clean (the jsoup jspecify nullability warnings are also gone, since ksoup is pure Kotlin).
- Temporary runtime smoke test (removed before commit) exercising `Ksoup.parse`, CSS selection, `first()`-null-on-empty, `ParseTorrentStatusUseCase`, and `ParsePostUseCase` (text/`<br>`/bold → `getWholeText()` + `tag().name()` paths) — all passed.
- `grep` confirms zero remaining `jsoup` references.

> Note: the full Android app build (`:app:assembleDebug` / `lintDebug` / `testDebugUnitTest`) was not run locally — it requires the Android SDK and the `google-services.json` secret, which aren't available in this environment. The change is contained to `:core:network:rutracker` (the only module that referenced jsoup) and its public API is unchanged, so downstream modules are unaffected at the source level. `ksoup` officially supports Android and pulls only small, pure-Kotlin, Android-safe transitive deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPxhiZbmURTJvhRzAHcpGu

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPxhiZbmURTJvhRzAHcpGu)_