### PR TITLE
Step 1: extract RuTrackerParser interface + TDD on real fixtures

### DIFF
--- a/core/network/rutracker/build.gradle.kts
+++ b/core/network/rutracker/build.gradle.kts
@@ -7,4 +7,6 @@ dependencies {
 
     implementation(libs.ktor.client.core)
     implementation(libs.ksoup)
+
+    testImplementation(libs.junit4)
 }

--- a/core/network/rutracker/src/main/kotlin/flow/network/api/RuTrackerApiFactory.kt
+++ b/core/network/rutracker/src/main/kotlin/flow/network/api/RuTrackerApiFactory.kt
@@ -15,10 +15,8 @@ import flow.network.domain.GetTopicUseCase
 import flow.network.domain.GetTorrentFileUseCase
 import flow.network.domain.GetTorrentUseCase
 import flow.network.domain.LoginUseCase
-import flow.network.domain.ParseCommentsPageUseCase
-import flow.network.domain.ParseTopicPageUseCase
-import flow.network.domain.ParseTorrentUseCase
 import flow.network.domain.RemoveFavoriteUseCase
+import flow.network.domain.RuTrackerHtmlParser
 import flow.network.domain.VerifyAuthorisedUseCase
 import flow.network.domain.VerifyTokenUseCase
 import flow.network.domain.WithAuthorisedCheckUseCase
@@ -31,22 +29,23 @@ import io.ktor.client.HttpClient
 object RuTrackerApiFactory {
     fun create(httpClient: HttpClient): NetworkApi {
         val api = RuTrackerInnerApiImpl(httpClient)
+        val parser = RuTrackerHtmlParser()
         val withTokenVerification = WithTokenVerificationUseCase(VerifyTokenUseCase)
         val withAuthorisedCheck = WithAuthorisedCheckUseCase(VerifyAuthorisedUseCase)
         return RuTrackerNetworkApi(
             AddCommentUseCase(api, withTokenVerification, withAuthorisedCheck, WithFormTokenUseCase),
             AddFavoriteUseCase(api, withTokenVerification, withAuthorisedCheck, WithFormTokenUseCase),
             CheckAuthorisedUseCase(api, VerifyAuthorisedUseCase),
-            GetCategoryPageUseCase(api),
-            GetCommentsPageUseCase(api, ParseCommentsPageUseCase),
-            GetFavoritesUseCase(api, withTokenVerification, withAuthorisedCheck),
-            GetForumUseCase(api),
-            GetSearchPageUseCase(api, withTokenVerification, withAuthorisedCheck),
-            GetTopicUseCase(api, ParseTorrentUseCase, ParseCommentsPageUseCase),
-            GetTopicPageUseCase(api, ParseTopicPageUseCase),
+            GetCategoryPageUseCase(api, parser),
+            GetCommentsPageUseCase(api, parser),
+            GetFavoritesUseCase(api, withTokenVerification, withAuthorisedCheck, parser),
+            GetForumUseCase(api, parser),
+            GetSearchPageUseCase(api, withTokenVerification, withAuthorisedCheck, parser),
+            GetTopicUseCase(api, parser),
+            GetTopicPageUseCase(api, parser),
             GetTorrentFileUseCase(api, withTokenVerification),
-            GetTorrentUseCase(api, ParseTorrentUseCase),
-            LoginUseCase(api, GetCurrentProfileUseCase(api, GetProfileUseCase(api))),
+            GetTorrentUseCase(api, parser),
+            LoginUseCase(api, GetCurrentProfileUseCase(api, GetProfileUseCase(api, parser), parser)),
             RemoveFavoriteUseCase(api, withTokenVerification, withAuthorisedCheck, WithFormTokenUseCase),
         )
     }

--- a/core/network/rutracker/src/main/kotlin/flow/network/domain/GetCategoryPageUseCase.kt
+++ b/core/network/rutracker/src/main/kotlin/flow/network/domain/GetCategoryPageUseCase.kt
@@ -1,112 +1,21 @@
 package flow.network.domain
 
-import com.fleeksoft.ksoup.Ksoup
 import flow.network.api.RuTrackerInnerApi
-import flow.network.dto.forum.CategoryDto
 import flow.network.dto.forum.CategoryPageDto
-import flow.network.dto.forum.SectionDto
-import flow.network.dto.topic.AuthorDto
-import flow.network.dto.topic.ForumTopicDto
-import flow.network.dto.topic.TopicDto
-import flow.network.dto.topic.TorrentDto
 import flow.network.model.Forbidden
 import flow.network.model.NotFound
 
-internal class GetCategoryPageUseCase(private val api: RuTrackerInnerApi) {
+internal class GetCategoryPageUseCase(
+    private val api: RuTrackerInnerApi,
+    private val parser: RuTrackerParser,
+) {
 
     suspend operator fun invoke(id: String, page: Int?): CategoryPageDto {
         val html = api.category(id, page)
         return when {
-            !isForumExists(html) -> throw NotFound
-            !isForumAvailableForUser(html) -> throw Forbidden
-            else -> parseCategoryPage(html, id)
-        }
-    }
-
-    companion object {
-
-        private fun isForumExists(html: String): Boolean {
-            return !html.contains("Ошибочный запрос: не задан forum_id") and
-                !html.contains("Такого форума не существует")
-        }
-
-        private fun isForumAvailableForUser(html: String): Boolean {
-            return !html.contains("Извините, только пользователи со специальными правами")
-        }
-
-        private fun parseCategoryPage(html: String, forumId: String): CategoryPageDto {
-            val doc = Ksoup.parse(html)
-            val currentPage = doc.select("#pagination > p:nth-child(1) > b:nth-child(1)").toInt(1)
-            val totalPages = doc.select("#pagination > p:nth-child(1) > b:nth-child(2)").toInt(1)
-            val forumName = doc.select(".maintitle").toStr()
-
-            val subforumNodes = doc.select(".forumlink > a")
-            val children = mutableListOf<CategoryDto>()
-            for (subforumNode in subforumNodes) {
-                val id = subforumNode.queryParam("f")
-                val name = subforumNode.toStr()
-                val subforum = CategoryDto(id, name)
-                children.add(subforum)
-            }
-
-            val sections = mutableListOf<SectionDto>()
-            val topics = mutableListOf<ForumTopicDto>()
-            var currentSection: String? = null
-            val currentSectionIds: MutableList<String> = mutableListOf()
-            val rows = doc.select("table.vf-table.forum > tbody > tr")
-            rows.forEach { element ->
-                if (element.children().any { it.hasClass("topicSep") }) {
-                    currentSection?.let { name ->
-                        sections.add(SectionDto(name, currentSectionIds.toList()))
-                    }
-                    currentSection = element.toStr()
-                    currentSectionIds.clear()
-                } else if (element.hasClass("hl-tr")) {
-                    val id = element.select("td").attr("id")
-                    val authorId = element.select("a.topicAuthor").queryParamOrNull("u")
-                    val authorName = element.select("a.topicAuthor").toStr()
-                    val seeds = element.select(".seedmed").toIntOrNull()
-                    val leeches = element.select(".leechmed").toIntOrNull()
-                    val size = element.select(".f-dl").text().replace("\u00a0", " ")
-                    val fullTitle = element.select(".tt-text").toStr()
-                    val title = getTitle(fullTitle)
-                    val tags = getTags(fullTitle)
-                    val status = ParseTorrentStatusUseCase(element)
-                    val author = if (authorName.isBlank()) {
-                        AuthorDto(name = element.select(".vf-col-author").toStr())
-                    } else {
-                        AuthorDto(id = authorId, name = authorName)
-                    }
-                    if (status == null) {
-                        topics.add(TopicDto(id, fullTitle, author))
-                    } else {
-                        topics.add(
-                            TorrentDto(
-                                id = id,
-                                title = title,
-                                tags = tags,
-                                status = status,
-                                author = author,
-                                size = size,
-                                seeds = seeds,
-                                leeches = leeches,
-                            ),
-                        )
-                    }
-                    currentSectionIds.add(id)
-                }
-            }
-            currentSection?.let { name ->
-                sections.add(SectionDto(name, currentSectionIds.toList()))
-            }
-            return CategoryPageDto(
-                category = CategoryDto(forumId, forumName),
-                page = currentPage,
-                pages = totalPages,
-                sections = sections.takeIf { it.size > 1 } ?: emptyList(),
-                children = children,
-                topics = topics,
-            )
+            !parser.isForumExists(html) -> throw NotFound
+            !parser.isForumAvailableForUser(html) -> throw Forbidden
+            else -> parser.parseCategoryPage(html, id)
         }
     }
 }

--- a/core/network/rutracker/src/main/kotlin/flow/network/domain/GetCommentsPageUseCase.kt
+++ b/core/network/rutracker/src/main/kotlin/flow/network/domain/GetCommentsPageUseCase.kt
@@ -7,7 +7,7 @@ import flow.network.model.NotFound
 
 internal class GetCommentsPageUseCase(
     private val api: RuTrackerInnerApi,
-    private val parseCommentsPageUseCase: ParseCommentsPageUseCase,
+    private val parser: RuTrackerParser,
 ) {
 
     suspend operator fun invoke(
@@ -17,10 +17,10 @@ internal class GetCommentsPageUseCase(
     ): CommentsPageDto {
         val html = api.topic(token, id, page)
         return when {
-            !isTopicExists(html) -> throw NotFound
-            isTopicModerated(html) -> throw Forbidden
-            isBlockedForRegion(html) -> throw Forbidden
-            else -> parseCommentsPageUseCase(html)
+            !parser.isTopicExists(html) -> throw NotFound
+            parser.isTopicModerated(html) -> throw Forbidden
+            parser.isBlockedForRegion(html) -> throw Forbidden
+            else -> parser.parseCommentsPage(html)
         }
     }
 }

--- a/core/network/rutracker/src/main/kotlin/flow/network/domain/GetCurrentProfileUseCase.kt
+++ b/core/network/rutracker/src/main/kotlin/flow/network/domain/GetCurrentProfileUseCase.kt
@@ -1,22 +1,14 @@
 package flow.network.domain
 
-import com.fleeksoft.ksoup.Ksoup
 import flow.network.api.RuTrackerInnerApi
 import flow.network.dto.user.ProfileDto
 
 internal class GetCurrentProfileUseCase(
     private val api: RuTrackerInnerApi,
     private val getProfileUseCase: GetProfileUseCase,
+    private val parser: RuTrackerParser,
 ) {
     suspend operator fun invoke(token: String): ProfileDto {
-        return getProfileUseCase(parseUserId(api.mainPage(token)))
-    }
-
-    companion object {
-        private fun parseUserId(html: String): String {
-            return Ksoup.parse(html)
-                .select("#logged-in-username")
-                .queryParam("u")
-        }
+        return getProfileUseCase(parser.parseCurrentUserId(api.mainPage(token)))
     }
 }

--- a/core/network/rutracker/src/main/kotlin/flow/network/domain/GetFavoritesUseCase.kt
+++ b/core/network/rutracker/src/main/kotlin/flow/network/domain/GetFavoritesUseCase.kt
@@ -1,93 +1,29 @@
 package flow.network.domain
 
-import com.fleeksoft.ksoup.Ksoup
 import flow.network.api.RuTrackerInnerApi
-import flow.network.dto.forum.CategoryDto
-import flow.network.dto.topic.AuthorDto
-import flow.network.dto.topic.ForumTopicDto
-import flow.network.dto.topic.TopicDto
-import flow.network.dto.topic.TorrentDto
 import flow.network.dto.user.FavoritesDto
 
 internal class GetFavoritesUseCase(
     private val api: RuTrackerInnerApi,
     private val withTokenVerificationUseCase: WithTokenVerificationUseCase,
     private val withAuthorisedCheckUseCase: WithAuthorisedCheckUseCase,
+    private val parser: RuTrackerParser,
 ) {
 
     suspend operator fun invoke(token: String): FavoritesDto {
         return withTokenVerificationUseCase(token) { validToken ->
             withAuthorisedCheckUseCase(api.favorites(validToken, 1)) { html ->
-                val pagesCount = parsePagesCount(html)
+                val pagesCount = parser.parseFavoritesPagesCount(html)
                 FavoritesDto(
                     (
-                        listOf(parseFavorites(html)) +
+                        listOf(parser.parseFavorites(html)) +
                             (2..pagesCount)
                                 .map { page -> api.favorites(token, page) }
-                                .map(::parseFavorites)
+                                .map(parser::parseFavorites)
                         )
                         .flatten(),
                 )
             }
-        }
-    }
-
-    companion object {
-        private fun parsePagesCount(html: String): Int {
-            val doc = Ksoup.parse(html)
-            val navigation = doc.select("#pagination")
-            val currentPage = navigation.select("b").toInt(1)
-            return maxOf(
-                navigation
-                    .select(".pg")
-                    .takeLast(2)
-                    .firstOrNull()
-                    .toInt(1),
-                currentPage,
-            )
-        }
-
-        private fun parseFavorites(html: String): List<ForumTopicDto> {
-            return Ksoup
-                .parse(html)
-                .select(".hl-tr")
-                .map { element ->
-                    val id = element.select(".topic-selector").attr("data-topic_id")
-                    val fullTitle = element.select(".torTopic.ts-text").toStr()
-                    val title = getTitle(fullTitle)
-                    val tags = getTags(fullTitle)
-                    val status = ParseTorrentStatusUseCase(element)
-                    val authorId = element.select(".topicAuthor").queryParamOrNull("u")
-                    val authorName = element.select(".topicAuthor > .topicAuthor").text()
-                    val author = AuthorDto(id = authorId, name = authorName)
-                    val categoryId =
-                        element.select(".t-forum-cell").select("a").last().queryParam("f")
-                    val categoryName = element.select(".t-forum-cell > .ts-text").toStr()
-                    val category = CategoryDto(categoryId, categoryName)
-                    if (status != null) {
-                        val size = element.select(".f-dl").text()
-                        val seeds = element.select(".seedmed").toIntOrNull()
-                        val leeches = element.select(".leechmed").toIntOrNull()
-                        TorrentDto(
-                            id = id,
-                            title = title,
-                            author = author,
-                            category = category,
-                            tags = tags,
-                            status = status,
-                            size = size,
-                            seeds = seeds,
-                            leeches = leeches,
-                        )
-                    } else {
-                        TopicDto(
-                            id = id,
-                            title = fullTitle,
-                            author = author,
-                            category = category,
-                        )
-                    }
-                }
         }
     }
 }

--- a/core/network/rutracker/src/main/kotlin/flow/network/domain/GetForumUseCase.kt
+++ b/core/network/rutracker/src/main/kotlin/flow/network/domain/GetForumUseCase.kt
@@ -1,46 +1,18 @@
 package flow.network.domain
 
-import com.fleeksoft.ksoup.Ksoup
 import flow.network.api.RuTrackerInnerApi
-import flow.network.dto.forum.CategoryDto
 import flow.network.dto.forum.ForumDto
 
-internal class GetForumUseCase(private val api: RuTrackerInnerApi) {
+internal class GetForumUseCase(
+    private val api: RuTrackerInnerApi,
+    private val parser: RuTrackerParser,
+) {
 
     suspend operator fun invoke(): ForumDto {
         if (ForumCache.expired()) {
-            ForumCache.cache = System.currentTimeMillis() to parseForumTree(api.forum())
+            ForumCache.cache = System.currentTimeMillis() to parser.parseForum(api.forum())
         }
         return ForumCache.cache!!.second
-    }
-
-    companion object {
-        private fun parseForumTree(html: String): ForumDto {
-            val doc = Ksoup.parse(html)
-            val categories = mutableListOf<CategoryDto>()
-            val treeRoots = doc.select(".tree-root")
-            treeRoots.forEach { categoryElement ->
-                val title = categoryElement.select(".c-title").attr("title")
-                val forums = mutableListOf<CategoryDto>()
-                val forumElements = categoryElement.child(0).child(1).children()
-                forumElements.forEach { forumElement ->
-                    val forumId = forumElement.child(0).select("a").url()
-                    val forumTitle = forumElement.child(0).select("a").toStr()
-                    val subforums = mutableListOf<CategoryDto>()
-                    if (forumElement.children().size > 1) {
-                        val subforumElements = forumElement.child(1).children()
-                        subforumElements.forEach { subforumElement ->
-                            val subforumId = subforumElement.select("a").url()
-                            val subforumTitle = subforumElement.toStr()
-                            subforums.add(CategoryDto(id = subforumId, name = subforumTitle))
-                        }
-                    }
-                    forums.add(CategoryDto(id = forumId, name = forumTitle, children = subforums))
-                }
-                categories.add(CategoryDto(name = title, children = forums))
-            }
-            return ForumDto(categories)
-        }
     }
 
     private object ForumCache {

--- a/core/network/rutracker/src/main/kotlin/flow/network/domain/GetProfileUseCase.kt
+++ b/core/network/rutracker/src/main/kotlin/flow/network/domain/GetProfileUseCase.kt
@@ -1,23 +1,13 @@
 package flow.network.domain
 
-import com.fleeksoft.ksoup.Ksoup
 import flow.network.api.RuTrackerInnerApi
 import flow.network.dto.user.ProfileDto
 
-internal class GetProfileUseCase(private val api: RuTrackerInnerApi) {
-
+internal class GetProfileUseCase(
+    private val api: RuTrackerInnerApi,
+    private val parser: RuTrackerParser,
+) {
     suspend operator fun invoke(id: String): ProfileDto {
-        return parseProfile(api.profile(id))
-    }
-
-    companion object {
-        private fun parseProfile(html: String): ProfileDto {
-            val doc = Ksoup.parse(html)
-            return ProfileDto(
-                id = doc.select("#profile-uname").attr("data-uid"),
-                name = doc.select("#profile-uname").toStr(),
-                avatarUrl = doc.select("#avatar-img > img").attr("src"),
-            )
-        }
+        return parser.parseProfile(api.profile(id))
     }
 }

--- a/core/network/rutracker/src/main/kotlin/flow/network/domain/GetSearchPageUseCase.kt
+++ b/core/network/rutracker/src/main/kotlin/flow/network/domain/GetSearchPageUseCase.kt
@@ -1,20 +1,16 @@
 package flow.network.domain
 
-import com.fleeksoft.ksoup.Ksoup
 import flow.network.api.RuTrackerInnerApi
-import flow.network.dto.forum.CategoryDto
 import flow.network.dto.search.SearchPageDto
 import flow.network.dto.search.SearchPeriodDto
 import flow.network.dto.search.SearchSortOrderDto
 import flow.network.dto.search.SearchSortTypeDto
-import flow.network.dto.topic.AuthorDto
-import flow.network.dto.topic.TorrentDto
-import flow.network.dto.topic.TorrentStatusDto
 
 internal class GetSearchPageUseCase(
     private val api: RuTrackerInnerApi,
     private val withTokenVerificationUseCase: WithTokenVerificationUseCase,
     private val withAuthorisedCheckUseCase: WithAuthorisedCheckUseCase,
+    private val parser: RuTrackerParser,
 ) {
 
     suspend operator fun invoke(
@@ -41,47 +37,8 @@ internal class GetSearchPageUseCase(
                     period = period,
                     page = page,
                 ),
-                ::parseSearchPage,
+                parser::parseSearchPage,
             )
-        }
-    }
-
-    companion object {
-        fun parseSearchPage(html: String): SearchPageDto {
-            val doc = Ksoup.parse(html)
-            val navigation =
-                doc.select("#main_content_wrap > div.bottom_info > div.nav > p:nth-child(1)")
-            val currentPage = navigation.select("b:nth-child(1)").toInt(1)
-            val totalPages = navigation.select("b:nth-child(2)").toInt(1)
-            val torrents = doc.select(".hl-tr").map { element ->
-                val id = element.select(".t-title > a").attr("data-topic_id")
-                val status = ParseTorrentStatusUseCase(element) ?: TorrentStatusDto.Checking
-                val titleWithTags = element.select(".t-title > a").toStr()
-                val title = getTitle(titleWithTags)
-                val tags = getTags(titleWithTags)
-                val authorId = element.select(".u-name > a").queryParamOrNull("pid")
-                val authorName = element.select(".u-name > a").text()
-                val author = AuthorDto(id = authorId, name = authorName)
-                val categoryId = element.select(".f").queryParam("f")
-                val categoryName = element.select(".f").toStr()
-                val size = formatSize(element.select(".tor-size").attr("data-ts_text").toLong())
-                val date = element.select("[style]").attr("data-ts_text").toLongOrNull()
-                val seeds = element.select(".seedmed").toIntOrNull()
-                val leeches = element.select(".leechmed").toIntOrNull()
-                TorrentDto(
-                    id = id,
-                    title = title,
-                    author = author,
-                    category = CategoryDto(categoryId, categoryName),
-                    tags = tags,
-                    status = status,
-                    date = date,
-                    size = size,
-                    seeds = seeds,
-                    leeches = leeches,
-                )
-            }
-            return SearchPageDto(currentPage, totalPages, torrents)
         }
     }
 }

--- a/core/network/rutracker/src/main/kotlin/flow/network/domain/GetTopicPageUseCase.kt
+++ b/core/network/rutracker/src/main/kotlin/flow/network/domain/GetTopicPageUseCase.kt
@@ -7,7 +7,7 @@ import flow.network.model.NotFound
 
 internal class GetTopicPageUseCase(
     private val api: RuTrackerInnerApi,
-    private val parseTopicPageUseCase: ParseTopicPageUseCase,
+    private val parser: RuTrackerParser,
 ) {
     suspend operator fun invoke(
         token: String,
@@ -16,10 +16,10 @@ internal class GetTopicPageUseCase(
     ): TopicPageDto {
         val html = api.topic(token, id, page)
         return when {
-            !isTopicExists(html) -> throw NotFound
-            isTopicModerated(html) -> throw Forbidden
-            isBlockedForRegion(html) -> throw Forbidden
-            else -> parseTopicPageUseCase(html)
+            !parser.isTopicExists(html) -> throw NotFound
+            parser.isTopicModerated(html) -> throw Forbidden
+            parser.isBlockedForRegion(html) -> throw Forbidden
+            else -> parser.parseTopicPage(html)
         }
     }
 }

--- a/core/network/rutracker/src/main/kotlin/flow/network/domain/GetTopicUseCase.kt
+++ b/core/network/rutracker/src/main/kotlin/flow/network/domain/GetTopicUseCase.kt
@@ -7,8 +7,7 @@ import flow.network.model.NotFound
 
 internal class GetTopicUseCase(
     private val api: RuTrackerInnerApi,
-    private val parseTorrentUseCase: ParseTorrentUseCase,
-    private val parseCommentsPageUseCase: ParseCommentsPageUseCase,
+    private val parser: RuTrackerParser,
 ) {
 
     suspend operator fun invoke(
@@ -18,16 +17,16 @@ internal class GetTopicUseCase(
     ): ForumTopicDto {
         val html = api.topic(token, id, page)
         return when {
-            !isTopicExists(html) -> throw NotFound
-            isTopicModerated(html) -> throw Forbidden
-            isBlockedForRegion(html) -> throw Forbidden
+            !parser.isTopicExists(html) -> throw NotFound
+            parser.isTopicModerated(html) -> throw Forbidden
+            parser.isBlockedForRegion(html) -> throw Forbidden
             else -> parseTopic(html)
         }
     }
 
-    private fun parseTopic(html: String) = if (html.contains("magnet:?")) {
-        parseTorrentUseCase(html)
+    private fun parseTopic(html: String) = if (parser.isTorrentTopic(html)) {
+        parser.parseTorrent(html)
     } else {
-        parseCommentsPageUseCase(html)
+        parser.parseCommentsPage(html)
     }
 }

--- a/core/network/rutracker/src/main/kotlin/flow/network/domain/GetTorrentUseCase.kt
+++ b/core/network/rutracker/src/main/kotlin/flow/network/domain/GetTorrentUseCase.kt
@@ -7,15 +7,15 @@ import flow.network.model.NotFound
 
 internal class GetTorrentUseCase(
     private val api: RuTrackerInnerApi,
-    private val parseTorrentUseCase: ParseTorrentUseCase,
+    private val parser: RuTrackerParser,
 ) {
     suspend operator fun invoke(token: String, id: String): TorrentDto {
         val html = api.topic(token, id)
         return when {
-            !isTopicExists(html) -> throw NotFound
-            isTopicModerated(html) -> throw Forbidden
-            isBlockedForRegion(html) -> throw Forbidden
-            else -> parseTorrentUseCase(html)
+            !parser.isTopicExists(html) -> throw NotFound
+            parser.isTopicModerated(html) -> throw Forbidden
+            parser.isBlockedForRegion(html) -> throw Forbidden
+            else -> parser.parseTorrent(html)
         }
     }
 }

--- a/core/network/rutracker/src/main/kotlin/flow/network/domain/RuTrackerHtmlParser.kt
+++ b/core/network/rutracker/src/main/kotlin/flow/network/domain/RuTrackerHtmlParser.kt
@@ -1,0 +1,313 @@
+package flow.network.domain
+
+import com.fleeksoft.ksoup.Ksoup
+import flow.network.dto.auth.CaptchaDto
+import flow.network.dto.forum.CategoryDto
+import flow.network.dto.forum.CategoryPageDto
+import flow.network.dto.forum.ForumDto
+import flow.network.dto.forum.SectionDto
+import flow.network.dto.search.SearchPageDto
+import flow.network.dto.topic.AuthorDto
+import flow.network.dto.topic.CommentsPageDto
+import flow.network.dto.topic.ForumTopicDto
+import flow.network.dto.topic.TopicDto
+import flow.network.dto.topic.TopicPageDto
+import flow.network.dto.topic.TorrentDto
+import flow.network.dto.topic.TorrentStatusDto
+import flow.network.dto.user.ProfileDto
+import java.util.regex.Pattern
+
+/**
+ * jsoup/ksoup-based [RuTrackerParser]. Parsing rules (CSS selectors, marker
+ * strings) live here; the focused `Parse*UseCase` objects are kept as the
+ * internal building blocks this implementation delegates to.
+ */
+internal class RuTrackerHtmlParser : RuTrackerParser {
+
+    // region pages → DTO
+
+    override fun parseSearchPage(html: String): SearchPageDto {
+        val doc = Ksoup.parse(html)
+        val navigation =
+            doc.select("#main_content_wrap > div.bottom_info > div.nav > p:nth-child(1)")
+        val currentPage = navigation.select("b:nth-child(1)").toInt(1)
+        val totalPages = navigation.select("b:nth-child(2)").toInt(1)
+        val torrents = doc.select(".hl-tr").map { element ->
+            val id = element.select(".t-title > a").attr("data-topic_id")
+            val status = ParseTorrentStatusUseCase(element) ?: TorrentStatusDto.Checking
+            val titleWithTags = element.select(".t-title > a").toStr()
+            val title = getTitle(titleWithTags)
+            val tags = getTags(titleWithTags)
+            val authorId = element.select(".u-name > a").queryParamOrNull("pid")
+            val authorName = element.select(".u-name > a").text()
+            val author = AuthorDto(id = authorId, name = authorName)
+            val categoryId = element.select(".f").queryParam("f")
+            val categoryName = element.select(".f").toStr()
+            val size = formatSize(element.select(".tor-size").attr("data-ts_text").toLong())
+            val date = element.select("[style]").attr("data-ts_text").toLongOrNull()
+            val seeds = element.select(".seedmed").toIntOrNull()
+            val leeches = element.select(".leechmed").toIntOrNull()
+            TorrentDto(
+                id = id,
+                title = title,
+                author = author,
+                category = CategoryDto(categoryId, categoryName),
+                tags = tags,
+                status = status,
+                date = date,
+                size = size,
+                seeds = seeds,
+                leeches = leeches,
+            )
+        }
+        return SearchPageDto(currentPage, totalPages, torrents)
+    }
+
+    override fun parseCategoryPage(html: String, categoryId: String): CategoryPageDto {
+        val doc = Ksoup.parse(html)
+        val currentPage = doc.select("#pagination > p:nth-child(1) > b:nth-child(1)").toInt(1)
+        val totalPages = doc.select("#pagination > p:nth-child(1) > b:nth-child(2)").toInt(1)
+        val forumName = doc.select(".maintitle").toStr()
+
+        val subforumNodes = doc.select(".forumlink > a")
+        val children = mutableListOf<CategoryDto>()
+        for (subforumNode in subforumNodes) {
+            val id = subforumNode.queryParam("f")
+            val name = subforumNode.toStr()
+            val subforum = CategoryDto(id, name)
+            children.add(subforum)
+        }
+
+        val sections = mutableListOf<SectionDto>()
+        val topics = mutableListOf<ForumTopicDto>()
+        var currentSection: String? = null
+        val currentSectionIds: MutableList<String> = mutableListOf()
+        val rows = doc.select("table.vf-table.forum > tbody > tr")
+        rows.forEach { element ->
+            if (element.children().any { it.hasClass("topicSep") }) {
+                currentSection?.let { name ->
+                    sections.add(SectionDto(name, currentSectionIds.toList()))
+                }
+                currentSection = element.toStr()
+                currentSectionIds.clear()
+            } else if (element.hasClass("hl-tr")) {
+                val id = element.select("td").attr("id")
+                val authorId = element.select("a.topicAuthor").queryParamOrNull("u")
+                val authorName = element.select("a.topicAuthor").toStr()
+                val seeds = element.select(".seedmed").toIntOrNull()
+                val leeches = element.select(".leechmed").toIntOrNull()
+                val size = element.select(".f-dl").text().replace("\u00a0", " ")
+                val fullTitle = element.select(".tt-text").toStr()
+                val title = getTitle(fullTitle)
+                val tags = getTags(fullTitle)
+                val status = ParseTorrentStatusUseCase(element)
+                val author = if (authorName.isBlank()) {
+                    AuthorDto(name = element.select(".vf-col-author").toStr())
+                } else {
+                    AuthorDto(id = authorId, name = authorName)
+                }
+                if (status == null) {
+                    topics.add(TopicDto(id, fullTitle, author))
+                } else {
+                    topics.add(
+                        TorrentDto(
+                            id = id,
+                            title = title,
+                            tags = tags,
+                            status = status,
+                            author = author,
+                            size = size,
+                            seeds = seeds,
+                            leeches = leeches,
+                        ),
+                    )
+                }
+                currentSectionIds.add(id)
+            }
+        }
+        currentSection?.let { name ->
+            sections.add(SectionDto(name, currentSectionIds.toList()))
+        }
+        return CategoryPageDto(
+            category = CategoryDto(categoryId, forumName),
+            page = currentPage,
+            pages = totalPages,
+            sections = sections.takeIf { it.size > 1 } ?: emptyList(),
+            children = children,
+            topics = topics,
+        )
+    }
+
+    override fun parseForum(html: String): ForumDto {
+        val doc = Ksoup.parse(html)
+        val categories = mutableListOf<CategoryDto>()
+        val treeRoots = doc.select(".tree-root")
+        treeRoots.forEach { categoryElement ->
+            val title = categoryElement.select(".c-title").attr("title")
+            val forums = mutableListOf<CategoryDto>()
+            val forumElements = categoryElement.child(0).child(1).children()
+            forumElements.forEach { forumElement ->
+                val forumId = forumElement.child(0).select("a").url()
+                val forumTitle = forumElement.child(0).select("a").toStr()
+                val subforums = mutableListOf<CategoryDto>()
+                if (forumElement.children().size > 1) {
+                    val subforumElements = forumElement.child(1).children()
+                    subforumElements.forEach { subforumElement ->
+                        val subforumId = subforumElement.select("a").url()
+                        val subforumTitle = subforumElement.toStr()
+                        subforums.add(CategoryDto(id = subforumId, name = subforumTitle))
+                    }
+                }
+                forums.add(CategoryDto(id = forumId, name = forumTitle, children = subforums))
+            }
+            categories.add(CategoryDto(name = title, children = forums))
+        }
+        return ForumDto(categories)
+    }
+
+    override fun parseTopicPage(html: String): TopicPageDto = ParseTopicPageUseCase(html)
+
+    override fun parseCommentsPage(html: String): CommentsPageDto = ParseCommentsPageUseCase(html)
+
+    override fun parseTorrent(html: String): TorrentDto = ParseTorrentUseCase(html)
+
+    override fun parseProfile(html: String): ProfileDto {
+        val doc = Ksoup.parse(html)
+        return ProfileDto(
+            id = doc.select("#profile-uname").attr("data-uid"),
+            name = doc.select("#profile-uname").toStr(),
+            avatarUrl = doc.select("#avatar-img > img").attr("src"),
+        )
+    }
+
+    override fun parseCurrentUserId(html: String): String {
+        return Ksoup.parse(html)
+            .select("#logged-in-username")
+            .queryParam("u")
+    }
+
+    override fun parseFavorites(html: String): List<ForumTopicDto> {
+        return Ksoup
+            .parse(html)
+            .select(".hl-tr")
+            .map { element ->
+                val id = element.select(".topic-selector").attr("data-topic_id")
+                val fullTitle = element.select(".torTopic.ts-text").toStr()
+                val title = getTitle(fullTitle)
+                val tags = getTags(fullTitle)
+                val status = ParseTorrentStatusUseCase(element)
+                val authorId = element.select(".topicAuthor").queryParamOrNull("u")
+                val authorName = element.select(".topicAuthor > .topicAuthor").text()
+                val author = AuthorDto(id = authorId, name = authorName)
+                val categoryId =
+                    element.select(".t-forum-cell").select("a").last().queryParam("f")
+                val categoryName = element.select(".t-forum-cell > .ts-text").toStr()
+                val category = CategoryDto(categoryId, categoryName)
+                if (status != null) {
+                    val size = element.select(".f-dl").text()
+                    val seeds = element.select(".seedmed").toIntOrNull()
+                    val leeches = element.select(".leechmed").toIntOrNull()
+                    TorrentDto(
+                        id = id,
+                        title = title,
+                        author = author,
+                        category = category,
+                        tags = tags,
+                        status = status,
+                        size = size,
+                        seeds = seeds,
+                        leeches = leeches,
+                    )
+                } else {
+                    TopicDto(
+                        id = id,
+                        title = fullTitle,
+                        author = author,
+                        category = category,
+                    )
+                }
+            }
+    }
+
+    override fun parseFavoritesPagesCount(html: String): Int {
+        val doc = Ksoup.parse(html)
+        val navigation = doc.select("#pagination")
+        val currentPage = navigation.select("b").toInt(1)
+        return maxOf(
+            navigation
+                .select(".pg")
+                .takeLast(2)
+                .firstOrNull()
+                .toInt(1),
+            currentPage,
+        )
+    }
+
+    override fun parseCaptcha(html: String): CaptchaDto? {
+        val codeMatcher = CaptchaCodeRegex.matcher(html)
+        val sidMatcher = CaptchaSidRegex.matcher(html)
+        val urlMatcher = CaptchaUrlRegex.matcher(html)
+        return if (codeMatcher.find() && sidMatcher.find() && urlMatcher.find()) {
+            val captchaUrl = urlMatcher.group(1).let { url ->
+                url.takeIf { it.contains("http") } ?: "https://${url.trim('/')}"
+            }
+            CaptchaDto(sidMatcher.group(1), codeMatcher.group(1), captchaUrl)
+        } else {
+            null
+        }
+    }
+
+    override fun parseFormToken(html: String): String {
+        val matcher = FormTokenRegex.matcher(html)
+        return if (matcher.find()) matcher.group(1) else ""
+    }
+
+    // endregion
+
+    // region state / markers
+
+    override fun isAuthorized(html: String) = html.contains("logged-in-username")
+
+    override fun isTorrentTopic(html: String) = html.contains("magnet:?")
+
+    override fun isTopicExists(html: String) =
+        !html.contains("Тема не найдена") &&
+            !html.contains("Тема находится в мусорке") &&
+            !html.contains("Ошибочный запрос: не указан topic_id")
+
+    override fun isTopicModerated(html: String) =
+        html.contains("Раздача ожидает проверки модератором")
+
+    override fun isBlockedForRegion(html: String) =
+        html.contains("Извините, раздача недоступна для вашего региона")
+
+    override fun isForumExists(html: String) =
+        !html.contains("Ошибочный запрос: не задан forum_id") and
+            !html.contains("Такого форума не существует")
+
+    override fun isForumAvailableForUser(html: String) =
+        !html.contains("Извините, только пользователи со специальными правами")
+
+    override fun hasLoginForm(html: String) = html.contains("login-form")
+
+    override fun isWrongCredentials(html: String) = html.contains("неверный пароль")
+
+    override fun isFavoriteAdded(html: String) = html.contains("Тема добавлена")
+
+    override fun isFavoriteRemoved(html: String) = html.contains("Тема удалена")
+
+    override fun isCommentSent(html: String) =
+        html.contains("Сообщение было успешно отправлено")
+
+    // endregion
+
+    private companion object {
+        val FormTokenRegex: Pattern = Pattern.compile("form_token: '(.*)',")
+        val CaptchaCodeRegex: Pattern =
+            Pattern.compile("<input[^>]*name=\"(cap_code_[^\"]+)\"[^>]*>")
+        val CaptchaSidRegex: Pattern =
+            Pattern.compile("<input[^>]*name=\"cap_sid\"[^>]*value=\"([^\"]+)\"[^>]*>")
+        val CaptchaUrlRegex: Pattern =
+            Pattern.compile("<img[^>]*src=\"([^\"]+/captcha/[^\"]+)\"[^>]*>")
+    }
+}

--- a/core/network/rutracker/src/main/kotlin/flow/network/domain/RuTrackerParser.kt
+++ b/core/network/rutracker/src/main/kotlin/flow/network/domain/RuTrackerParser.kt
@@ -1,0 +1,51 @@
+package flow.network.domain
+
+import flow.network.dto.auth.CaptchaDto
+import flow.network.dto.forum.CategoryPageDto
+import flow.network.dto.forum.ForumDto
+import flow.network.dto.search.SearchPageDto
+import flow.network.dto.topic.CommentsPageDto
+import flow.network.dto.topic.ForumTopicDto
+import flow.network.dto.topic.TopicPageDto
+import flow.network.dto.topic.TorrentDto
+import flow.network.dto.user.ProfileDto
+
+/**
+ * Extracts structured data from raw rutracker HTML.
+ *
+ * Pure: every method takes an HTML [String] and returns data — no network, no IO.
+ * This is the single seam that hides all markup/text knowledge, so the whole
+ * parsing layer can be swapped (e.g. for a config-driven implementation) behind it.
+ */
+internal interface RuTrackerParser {
+
+    // region pages → DTO
+    fun parseSearchPage(html: String): SearchPageDto
+    fun parseCategoryPage(html: String, categoryId: String): CategoryPageDto
+    fun parseForum(html: String): ForumDto
+    fun parseTopicPage(html: String): TopicPageDto
+    fun parseCommentsPage(html: String): CommentsPageDto
+    fun parseTorrent(html: String): TorrentDto
+    fun parseProfile(html: String): ProfileDto
+    fun parseCurrentUserId(html: String): String
+    fun parseFavorites(html: String): List<ForumTopicDto>
+    fun parseFavoritesPagesCount(html: String): Int
+    fun parseCaptcha(html: String): CaptchaDto?
+    fun parseFormToken(html: String): String
+    // endregion
+
+    // region state / markers
+    fun isAuthorized(html: String): Boolean
+    fun isTorrentTopic(html: String): Boolean
+    fun isTopicExists(html: String): Boolean
+    fun isTopicModerated(html: String): Boolean
+    fun isBlockedForRegion(html: String): Boolean
+    fun isForumExists(html: String): Boolean
+    fun isForumAvailableForUser(html: String): Boolean
+    fun hasLoginForm(html: String): Boolean
+    fun isWrongCredentials(html: String): Boolean
+    fun isFavoriteAdded(html: String): Boolean
+    fun isFavoriteRemoved(html: String): Boolean
+    fun isCommentSent(html: String): Boolean
+    // endregion
+}

--- a/core/network/rutracker/src/main/kotlin/flow/network/domain/Utils.kt
+++ b/core/network/rutracker/src/main/kotlin/flow/network/domain/Utils.kt
@@ -63,20 +63,6 @@ internal fun Elements?.queryParam(key: String): String {
     return requireNotNull(queryParamOrNull(key)) { "query param not found in $this" }
 }
 
-internal fun isTopicExists(html: String): Boolean {
-    return !html.contains("Тема не найдена") &&
-        !html.contains("Тема находится в мусорке") &&
-        !html.contains("Ошибочный запрос: не указан topic_id")
-}
-
-internal fun isBlockedForRegion(html: String): Boolean {
-    return html.contains("Извините, раздача недоступна для вашего региона")
-}
-
-internal fun isTopicModerated(html: String): Boolean {
-    return html.contains("Раздача ожидает проверки модератором")
-}
-
 internal fun getTitle(titleWithTags: String): String {
     return titleWithTags
         .replace("\\[[^]]*]".toRegex(), "")

--- a/core/network/rutracker/src/test/kotlin/flow/network/domain/Fixtures.kt
+++ b/core/network/rutracker/src/test/kotlin/flow/network/domain/Fixtures.kt
@@ -1,0 +1,9 @@
+package flow.network.domain
+
+/** Loads a real rutracker HTML page saved under `src/test/resources/fixtures/`. */
+internal object Fixtures {
+    fun load(name: String): String =
+        requireNotNull(Fixtures::class.java.getResourceAsStream("/fixtures/$name")) {
+            "fixture not found: /fixtures/$name"
+        }.bufferedReader().use { it.readText() }
+}

--- a/core/network/rutracker/src/test/kotlin/flow/network/domain/RuTrackerHtmlParserTest.kt
+++ b/core/network/rutracker/src/test/kotlin/flow/network/domain/RuTrackerHtmlParserTest.kt
@@ -1,0 +1,97 @@
+package flow.network.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Characterization tests for [RuTrackerHtmlParser] against real rutracker pages
+ * (see `src/test/resources/fixtures/`). Guest-viewable pages only for now —
+ * search/favorites/current-user require authenticated fixtures.
+ */
+class RuTrackerHtmlParserTest {
+
+    private val parser = RuTrackerHtmlParser()
+
+    private fun fixture(name: String) = Fixtures.load(name)
+
+    @Test
+    fun `parseProfile extracts id, name and avatar`() {
+        val profile = parser.parseProfile(fixture("profile.html"))
+
+        assertEquals("227805", profile.id)
+        assertEquals("filolya", profile.name)
+        assertTrue("avatar should be resolved", profile.avatarUrl.isNotBlank())
+    }
+
+    @Test
+    fun `parseForum returns a non-empty tree with nested forums`() {
+        val forum = parser.parseForum(fixture("forum_index.html"))
+
+        assertTrue("expected top-level categories", forum.children.isNotEmpty())
+        assertTrue(
+            "expected at least one category with forums",
+            forum.children.any { !it.children.isNullOrEmpty() },
+        )
+    }
+
+    @Test
+    fun `parseCategoryPage extracts category name and topics`() {
+        val page = parser.parseCategoryPage(fixture("category_page.html"), "2270")
+
+        assertEquals("2270", page.category.id)
+        assertTrue("category name should be resolved", page.category.name.isNotBlank())
+        assertFalse("expected topics", page.topics.isNullOrEmpty())
+    }
+
+    @Test
+    fun `parseTorrent extracts id, title and magnet`() {
+        val torrent = parser.parseTorrent(fixture("topic_torrent.html"))
+
+        assertEquals("6873596", torrent.id)
+        assertTrue("title: ${torrent.title}", torrent.title.contains("Мандалорец"))
+        assertTrue(torrent.magnetLink.orEmpty().startsWith("magnet:"))
+    }
+
+    @Test
+    fun `parseTopicPage extracts torrent data and comments`() {
+        val page = parser.parseTopicPage(fixture("topic_torrent.html"))
+
+        assertEquals("6873596", page.id)
+        assertTrue(page.title.contains("Мандалорец"))
+        assertNotNull("torrentData expected for a torrent topic", page.torrentData)
+        assertTrue(page.torrentData?.magnetLink.orEmpty().startsWith("magnet:"))
+        assertTrue("expected first post", page.commentsPage.posts.isNotEmpty())
+    }
+
+    @Test
+    fun `parseCommentsPage extracts title and posts with content`() {
+        val page = parser.parseCommentsPage(fixture("comments_page.html"))
+
+        assertEquals("5116006", page.id)
+        assertEquals("Мобильные устройства", page.title)
+        assertTrue("expected posts", page.posts.isNotEmpty())
+        assertTrue("every post should have an id", page.posts.all { it.id.isNotBlank() })
+        assertTrue("expected parsed post content", page.posts.any { it.children.isNotEmpty() })
+    }
+
+    @Test
+    fun `topic existence and torrent detection`() {
+        assertTrue(parser.isTopicExists(fixture("topic_torrent.html")))
+        assertFalse(parser.isTopicExists(fixture("topic_not_found.html")))
+        assertTrue(parser.isTorrentTopic(fixture("topic_torrent.html")))
+    }
+
+    @Test
+    fun `forum existence detection`() {
+        assertTrue(parser.isForumExists(fixture("category_page.html")))
+        assertFalse(parser.isForumExists(fixture("forum_not_found.html")))
+    }
+
+    @Test
+    fun `unauthenticated page is not authorized`() {
+        assertFalse(parser.isAuthorized(fixture("guest_unauthorized.html")))
+    }
+}

--- a/core/network/rutracker/src/test/resources/fixtures/category_page.html
+++ b/core/network/rutracker/src/test/resources/fixtures/category_page.html
@@ -1,0 +1,2433 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+
+<meta charset="Windows-1251">
+<meta name="robots" content="noindex">
+	<link rel="canonical" href="https://rutracker.org/forum/viewforum.php?f=252">
+
+<title>Фильмы 2026 [стр. 1] :: Кино, Видео и ТВ :: RuTracker.org</title>
+
+<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+<link rel="manifest" href="/manifest.json">
+<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
+<meta name="msapplication-TileColor" content="#2b5797">
+<meta name="msapplication-TileImage" content="/mstile-144x144.png">
+<meta name="theme-color" content="#ffffff">
+
+<link rel="search" type="application/opensearchdescription+xml" title="Поиск на RuTracker.org" href="https://static.rutracker.cc/opensearch.xml">
+<link href="https://feed.rutracker.cc/atom/f/252.atom" rel="alternate" type="application/atom+xml" title="Фильмы 2026" />
+
+<script>
+window.BB = {
+	cur_domain: location.hostname.replace(/.*?(([a-z0-9-]+\.){1,2}[a-z0-9-]+)$/, '$1'),
+	form_token: '',
+	opt_js: {},
+
+	IS_GUEST: !!'1',
+	IMG_URL: 'https://static.rutracker.cc/templates/v1/images',
+	SMILES_URL: 'https://static.rutracker.cc/smiles',
+	catId: 2,
+	FORUM_ID: 252,
+	parentForumId: 7,
+		PG_PER_PAGE: '50',
+	PG_BASE_URL: 'viewforum.php?f=252',
+		COOKIE_MARK: 'bb_mark_read',
+	};
+BB.cookie_defaults = {
+	domain: '.' + BB.cur_domain,
+	path: "/forum/",
+};
+</script>
+<link href="https://static.rutracker.cc/templates/v1/min/eb83350bae3880e4073b81d26294de5d.all.min.css" rel="stylesheet">
+<script src="https://static.rutracker.cc/templates/v1/min/4e695e8ea9cf5a1dcc7aed231b887c51.lib.min.js"></script>
+<script src="https://static.rutracker.cc/templates/v1/min/3b60ab3546ba966484df4c3099b918ab.bb.min.js"></script>
+
+
+
+<style>
+.invisible-el {
+	/* @include element-invisible(); */
+	clip: rect(1px, 1px, 1px, 1px);
+	height: 1px;
+	overflow: hidden;
+	position: absolute !important;
+	width: 1px;
+}
+.hidden, .menu-sub, #ajax-loading, #ajax-error, var.ajax-params, #modal-blocker, .q-post {
+	display: none;
+}
+/**/
+#logo {
+	min-height: auto;
+}
+/**/
+/* temp */
+/* temp end */
+</style>
+
+<noscript>
+	<style>
+	.sp-body {
+		display: block; /* for bots */
+	}
+	</style>
+</noscript>
+
+</head>
+
+<body class="" style="">
+
+<div id="invisible-heap" class="invisible-el"></div>
+<div id="preload" class="invisible-el"></div>
+
+<div class="menu-sub" id="pg-jump">
+	<table style="border-spacing: 1px;">
+	<tr>
+		<th style="padding: 2px;">К странице...</th>
+	</tr>
+	<tr>
+		<td style="padding: 2px;">
+			<form onsubmit="BB.go_to_page( $('#pg-page').val() ); return false;">
+				<input id="pg-page" type="text" size="5" maxlength="4">
+				<input type="submit" value="Перейти">
+			</form>
+		</td>
+	</tr>
+	</table>
+</div>
+
+
+<div id="body_container">
+
+		<script>
+	if (top != self && !self.location.hostname.match(BB.allowed_translator_hosts)) {
+		$(function () {
+			$('body').html('<h1 style="text-align: center;"><br><br>Похоже, вас пытаются обмануть<br>frame\'s hostname: ' + self.location.hostname + '</h1>');
+			throw new Error('in frame');
+		});
+	}
+		</script>
+
+	<div id="page_container">
+
+		<div id="page_header" class="hide-for-print">
+
+			<div id="main-nav" class="site-nav clearfix">
+				<ul class="inlined middot-separated floatL">
+					<li>
+						<a href="index.php"><b>Главная</b></a>
+					</li>
+					<li>
+													<a href="tracker.php" rel="nofollow"><b>Трекер</b></a>
+											</li>
+					<li>
+						<a href="search.php" rel="nofollow"><b>Поиск</b></a>
+					</li>
+					<li>
+						<a href="groupcp.php" rel="nofollow"><b>Группы</b></a>
+					</li>
+					<li>
+						<a href="https://rutracker.wiki/" target="_blank"><b>FAQ</b></a>
+					</li>
+					<li>
+						<a href="viewtopic.php?t=6812335" style="color: #7b1fa2;"><b>VPN</b></a>
+					</li>
+					<li>
+						<a href="viewtopic.php?t=1045"><b>Правила</b></a>
+					</li>
+					<li>
+						<a href="viewtopic.php?t=6452965" style="color: #880e4f;"><b>Донаты</b></a>
+					</li>
+									</ul>
+											</div>
+			<!--/main-nav-->
+
+			
+			<div id="logo">
+				<table style="">
+				<tr>
+					<td id="logo-td" style="padding: 3px 7px 3px 15px;">
+						<a href="index.php" class="site-logo-link">
+								<img class="site-logo"
+		src="https://static.rutracker.cc/logo/logo-3.svg"
+		style=""
+		alt="logo">
+							</a>
+					</td>
+					<td class="tCenter w100" style="padding: 6px 10px 0 3px;">
+											</td>
+				</tr>
+				</table>
+			</div>
+			<!--/logo-->
+
+						<div class="topmenu">
+				<table class="w100">
+				<tr>
+					
+					<td class="tCenter pad_2 nowrap">
+						<div>
+															<a href="profile.php?mode=register" rel="nofollow"><b>Регистрация</b></a>
+								&nbsp;&#0183;&nbsp;
+								<a href="#" onclick="BB.toggle_top_login(); return false;" tabindex="5"><b>Вход</b></a>
+
+								<div id="top-login-box">
+									<form id="quick-search-guest" method="get" action="tracker.php">
+										<input id="search-text-guest" type="text" name="nm" value="" tabindex="1" accesskey="q">
+										<input type="submit" value="поиск" tabindex="2">
+									</form>
+									<form id="login-form-quick" method="post" action="login.php" style="display: none;">
+																				<input id="top-login-uname" type="text" name="login_username" tabindex="1" accesskey="l" placeholder="имя">
+										<input id="top-login-pwd" type="password" name="login_password" tabindex="2" placeholder="пароль">
+										<label title="Защищенное соединение" class="login-ssl-block" style="display: none;">
+											<input class="login-ssl" type="checkbox" tabindex="3" checked>SSL
+										</label>
+										<input id="top-login-btn" type="submit" name="login" value="вход" tabindex="4">
+									</form>
+								</div>
+
+								<a href="otp.php" rel="nofollow"><b>Забыли имя или пароль?</b></a>
+													</div>
+					</td>
+
+					
+				</tr>
+				</table>
+			</div><!--/topmenu-->
+			
+			
+		</div>
+		<!--/page_header-->
+
+		
+		<div id="page_content">
+			<table style="width: 100%; border: none;">
+			<tr>
+
+				
+				<td id="main_content">
+					<div id="main_content_wrap">
+
+						
+						
+						
+						
+						<!--/page_header.tpl-->
+
+<table class="w100">
+<tr>
+	<td class="w100 vBottom pad_2">
+		<h1 class="maintitle"><a href="viewforum.php?f=252">Фильмы 2026</a></h1>
+						<div class="small" style="margin: 16px 4px 8px;">
+			<b><span class="pg-jump-menu"><a class="menu-root" href="#pg-jump" onclick="BB.focus_pg_input();">Страницы</a> :&nbsp;&nbsp;</span><b>1</b>, <a class="pg" href="viewforum.php?f=252&amp;start=50">2</a>, <a class="pg" href="viewforum.php?f=252&amp;start=100">3</a>, <a class="pg" href="viewforum.php?f=252&amp;start=150">4</a>, <a class="pg" href="viewforum.php?f=252&amp;start=200">5</a>&nbsp;&nbsp;<a class="pg" href="viewforum.php?f=252&amp;start=50">След.</a></b>
+		</div>
+		
+		<table class="w100">
+		<tr>
+			<td class="pad_2"><a href="posting.php?f=252&amp;mode=newtopic" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/post.gif" alt="Новая тема"></a></td>
+			<td class="nav nav-top w100 pad_2">
+				&nbsp;<a href="index.php?c=2" rel="nofollow">Кино, Видео и ТВ</a>
+								<em>&raquo;</em>&nbsp;<a href="viewforum.php?f=7">Зарубежное кино</a>
+								<em>&raquo;</em>&nbsp;<a href="viewforum.php?f=252">Фильмы 2026</a>
+			</td>
+		</tr>
+		</table>
+
+	</td>
+	<td class="pad_2">
+			</td>
+</tr>
+</table>
+
+
+<a id="topics"></a>
+
+
+
+<table class="vf-table vf-tor forumline forum">
+<colgroup>
+	<col class="row1 vf-col-icon">
+	<col class="row1 vf-col-t-title">
+	<col class="row2 vf-col-tor">
+	<col class="row2 vf-col-replies">
+	<col class="row2 vf-col-last-post">
+</colgroup>
+<tr>
+	<th class="vf-col-icon"></th>
+	<th class="vf-col-t-title">Темы</th>
+	<th class="vf-col-tor">Торрент</th>
+	<th class="vf-col-replies">Отв.</th>
+	<th class="vf-col-last-post">Посл. сообщение</th>
+</tr>
+<tr>
+	<td colspan="5" class="row3 topicSep">Темы</td>
+</tr>
+<tr id="tr-6873969" class="hl-tr" data-topic_id="6873969">
+	<td id="6873969" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6873969" href="viewtopic.php?t=6873969" class="torTopic bold tt-text">Доктор Глас / Doktor Glas / Doctor Glas (Эрик Леййонборг / Erik Leijonborg) [2026, Швеция, триллер, WEB-DLRip-AV<wbr>C] MVO (MUZOBOZ) + Sub Rus, Dan, Fin, Nor, Swe + Original Swe</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=43026051" rel="nofollow" class="topicAuthor">vitolinform</a>
+								</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>299</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>76</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6873969" rel="nofollow" class="small f-dl dl-stub">1.87&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">18</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>1,138</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-23 23:27</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=43414579" rel="nofollow">jsgjsgfwrt</a>			<a href="viewtopic.php?p=89304925#89304925" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6872159" class="hl-tr" data-topic_id="6872159">
+	<td id="6872159" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6872159" href="viewtopic.php?t=6872159" class="torTopic bold tt-text">Давление / Pressure (Энтони Марас / Anthony Maras) [2026, Великобритан<wbr>ия, Франция, США, военный, драма, история, WEB-DLRip] MVO (HDRezka Studio)</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=8679101" rel="nofollow" class="topicAuthor">порошков</a>
+						<span class="topicPG">&nbsp;[<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1" alt=""> <a href="viewtopic.php?t=6872159"  rel="nofollow">1</a>, <a href="viewtopic.php?t=6872159&amp;start=30"  rel="nofollow">2</a> ]</span>		</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>736</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>101</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6872159" rel="nofollow" class="small f-dl dl-stub">1.46&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">44</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>4,793</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-23 23:01</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=41731324" rel="nofollow">matudo</a>			<a href="viewtopic.php?p=89304863#89304863" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6873596" class="hl-tr" data-topic_id="6873596">
+	<td id="6873596" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6873596" href="viewtopic.php?t=6873596" class="torTopic bold tt-text">Мандалорец и Грогу / The Mandalorian &amp; Grogu (Джон Фавро / Jon Favreau) [2026, США, фантастика, фэнтези, боевик, приключения,<wbr> семейный, WEBRip] [Локализованн<wbr>ый видеоряд] Dub (MovieDalen)<wbr></a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=8679101" rel="nofollow" class="topicAuthor">порошков</a>
+						<span class="topicPG">&nbsp;[<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1" alt=""> <a href="viewtopic.php?t=6873596"  rel="nofollow">1</a>, <a href="viewtopic.php?t=6873596&amp;start=30"  rel="nofollow">2</a> ]</span>		</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>1925</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>398</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6873596" rel="nofollow" class="small f-dl dl-stub">1.46&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">42</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>7,415</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-23 22:53</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=9888699" rel="nofollow">ophidia</a>			<a href="viewtopic.php?p=89304843#89304843" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6826279" class="hl-tr" data-topic_id="6826279">
+	<td id="6826279" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6826279" href="viewtopic.php?t=6826279" class="torTopic bold tt-text">Военная машина / War Machine (Патрик Хьюз / Patrick Hughes) [2026, Великобритан<wbr>ия, Австралия, Новая Зеландия, США, фантастика, боевик, WEB-DLRip-AV<wbr>C] Dub (Videofilm Int.) + Original Eng + Sub Rus, Eng</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=23770535" rel="nofollow" class="topicAuthor">_ivanes</a>
+						<span class="topicPG">&nbsp;[<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1" alt=""> <a href="viewtopic.php?t=6826279"  rel="nofollow">1</a> .. <a href="viewtopic.php?t=6826279&amp;start=210"  rel="nofollow">8</a>, <a href="viewtopic.php?t=6826279&amp;start=240"  rel="nofollow">9</a> ]</span>		</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>498</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>23</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6826279" rel="nofollow" class="small f-dl dl-stub">2.4&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">246</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>24,156</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-23 22:47</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=23827957" rel="nofollow">michaily4</a>			<a href="viewtopic.php?p=89304820#89304820" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6833244" class="hl-tr" data-topic_id="6833244">
+	<td id="6833244" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6833244" href="viewtopic.php?t=6833244" class="torTopic bold tt-text">Острые козырьки: Бессмертный человек / Peaky Blinders: The Immortal Man (Том Харпер / Tom Harper) [2026, Великобритан<wbr>ия, Франция, США, криминал, драма, история, WEB-DLRip] MVO (HDRezka Studio)</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=8679101" rel="nofollow" class="topicAuthor">порошков</a>
+						<span class="topicPG">&nbsp;[<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1" alt=""> <a href="viewtopic.php?t=6833244"  rel="nofollow">1</a>, <a href="viewtopic.php?t=6833244&amp;start=30"  rel="nofollow">2</a> ]</span>		</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>250</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>8</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6833244" rel="nofollow" class="small f-dl dl-stub">1.46&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">59</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>11,069</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-23 22:10</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=11539366" rel="nofollow">Di-Murk</a>			<a href="viewtopic.php?p=89304723#89304723" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6871101" class="hl-tr" data-topic_id="6871101">
+	<td id="6871101" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6871101" href="viewtopic.php?t=6871101" class="torTopic bold tt-text">Они придут за тобой / They Will Kill You (Кирилл Соколов / Kirill Sokolov) [2026, США, Канада, ЮАР, боевик, комедия, ужасы, HDRip] Dub (Movie Dubbing)</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=8679101" rel="nofollow" class="topicAuthor">порошков</a>
+								</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>140</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>14</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6871101" rel="nofollow" class="small f-dl dl-stub">1.45&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">11</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>1,429</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-23 21:30</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=10250936" rel="nofollow">littlegene</a>			<a href="viewtopic.php?p=89304593#89304593" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6872794" class="hl-tr" data-topic_id="6872794">
+	<td id="6872794" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6872794" href="viewtopic.php?t=6872794" class="torTopic bold tt-text">Укротитель шторма: Легенда о молотоглавом<wbr> / The Islander / Storm Rider: Legend of Hammerhead (Зоран Лисинац, Домагой Мазуран / Zoran Lisinac, Domagoj Mazuran) [2026, Хорватия, США, Великобритан<wbr>ия, Фантастика, боевик, приключения,<wbr> WEB-DLRip-AV<wbr>C] Dub (OKKO)</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=697078" rel="nofollow" class="topicAuthor">cocka1</a>
+								</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>345</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>49</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6872794" rel="nofollow" class="small f-dl dl-stub">1.46&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">18</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>2,644</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-23 21:28</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=41249013" rel="nofollow">Bill Strannix</a>			<a href="viewtopic.php?p=89304585#89304585" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6872805" class="hl-tr" data-topic_id="6872805">
+	<td id="6872805" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6872805" href="viewtopic.php?t=6872805" class="torTopic bold tt-text">Глубокие воды / Крушение рейса 1405 / Deep Water (Ренни Харлин / Renny Harlin) [2026, Испания, Новая Зеландия, США, Китай, Ужасы, боевик, триллер, WEB-DLRip-AV<wbr>C] Dub (WinMedia) + Sub (Rus, Eng)</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=697078" rel="nofollow" class="topicAuthor">cocka1</a>
+								</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>237</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>49</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6872805" rel="nofollow" class="small f-dl dl-stub">1.46&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">19</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>2,137</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-23 21:22</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=12692737" rel="nofollow">CATFISH-2</a>			<a href="viewtopic.php?p=89304570#89304570" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6869541" class="hl-tr" data-topic_id="6869541">
+	<td id="6869541" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6869541" href="viewtopic.php?t=6869541" class="torTopic bold tt-text">Майкл / Michael (Антуан Фукуа / Antoine Fuqua) [2026, США, Великобритан<wbr>ия, биография, музыка, драма, WEB-DLRip] Dub (UltradoxStu<wbr>dio)</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=8679101" rel="nofollow" class="topicAuthor">порошков</a>
+						<span class="topicPG">&nbsp;[<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1" alt=""> <a href="viewtopic.php?t=6869541"  rel="nofollow">1</a>, <a href="viewtopic.php?t=6869541&amp;start=30"  rel="nofollow">2</a> ]</span>		</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>670</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>111</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6869541" rel="nofollow" class="small f-dl dl-stub">1.46&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">38</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>7,729</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-23 21:18</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=6202761" rel="nofollow">frecords72</a>			<a href="viewtopic.php?p=89304551#89304551" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6860589" class="hl-tr" data-topic_id="6860589">
+	<td id="6860589" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6860589" href="viewtopic.php?t=6860589" class="torTopic bold tt-text">Мумия / The Mummy / Lee Cronin's The Mummy (Ли Кронин / Lee Cronin) [2026, Ирландия, США, Испания, Канада, ужасы, WEB-DLRip-AV<wbr>C] MVO (HDRezka Studio) + Sub Rus, Eng, Ukr, Fra, Spa + Original Eng</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=43026051" rel="nofollow" class="topicAuthor">vitolinform</a>
+						<span class="topicPG">&nbsp;[<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1" alt=""> <a href="viewtopic.php?t=6860589"  rel="nofollow">1</a>, <a href="viewtopic.php?t=6860589&amp;start=30"  rel="nofollow">2</a>, <a href="viewtopic.php?t=6860589&amp;start=60"  rel="nofollow">3</a> ]</span>		</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>372</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>29</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6860589" rel="nofollow" class="small f-dl dl-stub">2.44&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">71</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>9,874</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-23 20:34</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=14545592" rel="nofollow">lunarman</a>			<a href="viewtopic.php?p=89304412#89304412" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6869268" class="hl-tr" data-topic_id="6869268">
+	<td id="6869268" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6869268" href="viewtopic.php?t=6869268" class="torTopic bold tt-text">Цвета зла: Чёрный / Kolory z&#322;a: Czer&#324; / Colors of Evil: Black (Адриан Панек / Adrian Panek) [2026, Польша, драма, криминал, WEB-DLRip] Dub (Movie Dubbing) + Sub Rus</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=43748518" rel="nofollow" class="topicAuthor">JNS82</a>
+						<span class="topicPG">&nbsp;[<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1" alt=""> <a href="viewtopic.php?t=6869268"  rel="nofollow">1</a>, <a href="viewtopic.php?t=6869268&amp;start=30"  rel="nofollow">2</a> ]</span>		</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>413</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>29</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6869268" rel="nofollow" class="small f-dl dl-stub">1.46&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">30</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>4,577</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-23 20:28</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=14545592" rel="nofollow">lunarman</a>			<a href="viewtopic.php?p=89304390#89304390" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6857290" class="hl-tr" data-topic_id="6857290">
+	<td id="6857290" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6857290" href="viewtopic.php?t=6857290" class="torTopic bold tt-text">Проект «Конец света» / Project Hail Mary (Фил Лорд, Кристофер Миллер / Phil Lord, Christopher Miller) [2026, США, Фантастика, триллер, драма, WEB-DLRip] [IMAX] Dub (MovieDalen)<wbr> + Sub Rus</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=697078" rel="nofollow" class="topicAuthor">cocka1</a>
+								</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>291</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>48</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6857290" rel="nofollow" class="small f-dl dl-stub">1.46&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">25</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>6,914</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-23 20:24</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=8788830" rel="nofollow">Elknik</a>			<a href="viewtopic.php?p=89304378#89304378" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6869184" class="hl-tr" data-topic_id="6869184">
+	<td id="6869184" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-dup">T</span>&#0183;												<a id="tt-6869184" href="viewtopic.php?t=6869184" class="torTopic bold tt-text">Майкл / Michael (Антуан Фукуа / Antoine Fuqua) [2026, США, Великобритан<wbr>ия, биография, музыка, драма, WEB-DLRip-AV<wbr>C] Dub (ПроДубляж) + Sub Rus, Eng + Original Eng</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=43026051" rel="nofollow" class="topicAuthor">vitolinform</a>
+						<span class="topicPG">&nbsp;[<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1" alt=""> <a href="viewtopic.php?t=6869184"  rel="nofollow">1</a> .. <a href="viewtopic.php?t=6869184&amp;start=60"  rel="nofollow">3</a>, <a href="viewtopic.php?t=6869184&amp;start=90"  rel="nofollow">4</a> ]</span>		</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>2321</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>210</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6869184" rel="nofollow" class="small f-dl dl-stub">3.09&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">114</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>24,427</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-23 19:51</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=45895734" rel="nofollow">Сергей 73</a>			<a href="viewtopic.php?p=89304281#89304281" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6864899" class="hl-tr" data-topic_id="6864899">
+	<td id="6864899" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6864899" href="viewtopic.php?t=6864899" class="torTopic bold tt-text">Опасные отношения / Over Your Dead Body (Йорма Такконе / Jorma Taccone) [2026, США, боевик, триллер, комедия, WEB-DLRip-AV<wbr>C] MVO (HDRezka Studio) + Sub Rus, Eng + Original Eng</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=43026051" rel="nofollow" class="topicAuthor">vitolinform</a>
+						<span class="topicPG">&nbsp;[<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1" alt=""> <a href="viewtopic.php?t=6864899"  rel="nofollow">1</a>, <a href="viewtopic.php?t=6864899&amp;start=30"  rel="nofollow">2</a> ]</span>		</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>830</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>51</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6864899" rel="nofollow" class="small f-dl dl-stub">1.85&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">49</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>12,365</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-23 19:05</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=11042214" rel="nofollow">explorat1on</a>			<a href="viewtopic.php?p=89304133#89304133" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6854850" class="hl-tr" data-topic_id="6854850">
+	<td id="6854850" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6854850" href="viewtopic.php?t=6854850" class="torTopic bold tt-text">Кракен / Kraken (Пол Ойе / P&#229;l &#216;ie) [2026, Норвегия, боевик, фантастика, драма, ужасы, триллер, WEB-DLRip-AV<wbr>C] MVO (MUZOBOZ) + Sub Rus, Eng, Nor, Dan, Fin, Swe + Original Nor</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=43026051" rel="nofollow" class="topicAuthor">vitolinform</a>
+						<span class="topicPG">&nbsp;[<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1" alt=""> <a href="viewtopic.php?t=6854850"  rel="nofollow">1</a> .. <a href="viewtopic.php?t=6854850&amp;start=90"  rel="nofollow">4</a>, <a href="viewtopic.php?t=6854850&amp;start=120"  rel="nofollow">5</a> ]</span>		</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>373</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>29</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6854850" rel="nofollow" class="small f-dl dl-stub">1.4&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">121</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>13,652</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-23 19:04</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=17889439" rel="nofollow">Данте_Алигьери</a>			<a href="viewtopic.php?p=89304130#89304130" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6869505" class="hl-tr" data-topic_id="6869505">
+	<td id="6869505" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-dup">T</span>&#0183;												<a id="tt-6869505" href="viewtopic.php?t=6869505" class="torTopic bold tt-text">Властелины вселенной / Masters of the Universe (Трэвис Найт / Travis Knight) [2026, США, фантастика, фэнтези, боевик, приключения,<wbr> Telesync] MVO (&quot;Смотри Кино!')</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=4737622" rel="nofollow" class="topicAuthor">rjhlb777</a>
+						<span class="topicPG">&nbsp;[<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1" alt=""> <a href="viewtopic.php?t=6869505"  rel="nofollow">1</a>, <a href="viewtopic.php?t=6869505&amp;start=30"  rel="nofollow">2</a>, <a href="viewtopic.php?t=6869505&amp;start=60"  rel="nofollow">3</a> ]</span>		</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>1025</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>81</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6869505" rel="nofollow" class="small f-dl dl-stub">4.21&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">65</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>11,168</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-23 18:45</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=1289409" rel="nofollow">woolfick</a>			<a href="viewtopic.php?p=89304067#89304067" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6865550" class="hl-tr" data-topic_id="6865550">
+	<td id="6865550" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6865550" href="viewtopic.php?t=6865550" class="torTopic bold tt-text">Пропеллер: Ночной рейс в один конец / Propeller One-Way Night Coach (Джон Траволта / John Travolta) [2026, США, драма, приключения,<wbr> семейный, WEB-DLRip-AV<wbr>C] MVO (WinMedia) + Sub Rus, Eng + Original Eng</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=43026051" rel="nofollow" class="topicAuthor">vitolinform</a>
+								</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>189</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>16</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6865550" rel="nofollow" class="small f-dl dl-stub">1.46&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">24</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>3,073</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-23 18:22</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=427803" rel="nofollow">shurik_144</a>			<a href="viewtopic.php?p=89304000#89304000" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6873268" class="hl-tr" data-topic_id="6873268">
+	<td id="6873268" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6873268" href="viewtopic.php?t=6873268" class="torTopic bold tt-text">Три сыщика: Проклятие острова мёртвых / Die drei???: Toteninsel / The Three Investigator<wbr>s: Isle of Death (Тим Дюньшеде / Tim D&#252;nschede<wbr>) [2026, Германия, приключение,<wbr> HDRip-AVC] MVO (MUZOBOZ) + Sub Rus, Eng, Deu + Original Deu</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=43026051" rel="nofollow" class="topicAuthor">vitolinform</a>
+								</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>159</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>29</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6873268" rel="nofollow" class="small f-dl dl-stub">1.87&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">8</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>865</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-23 17:41</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=55131609" rel="nofollow">freesdx2</a>			<a href="viewtopic.php?p=89303890#89303890" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6862677" class="hl-tr" data-topic_id="6862677">
+	<td id="6862677" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6862677" href="viewtopic.php?t=6862677" class="torTopic bold tt-text">Сначала дамы / Ladies First (Теа Шэррок / Thea Sharrock) [2026, США, комедия, WEB-DLRip-AV<wbr>C] Dub (WinMedia) + Sub Rus, Eng + Original Eng</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=43026051" rel="nofollow" class="topicAuthor">vitolinform</a>
+						<span class="topicPG">&nbsp;[<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1" alt=""> <a href="viewtopic.php?t=6862677"  rel="nofollow">1</a>, <a href="viewtopic.php?t=6862677&amp;start=30"  rel="nofollow">2</a>, <a href="viewtopic.php?t=6862677&amp;start=60"  rel="nofollow">3</a> ]</span>		</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>1358</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>74</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6862677" rel="nofollow" class="small f-dl dl-stub">1.58&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">72</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>17,612</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-23 14:46</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=4129274" rel="nofollow">Down23</a>			<a href="viewtopic.php?p=89303418#89303418" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6873100" class="hl-tr" data-topic_id="6873100">
+	<td id="6873100" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6873100" href="viewtopic.php?t=6873100" class="torTopic bold tt-text">Глубокие воды / Крушение рейса 1405 / Deep Water (Ренни Харлин / Renny Harlin) [2026, Испания, Новая Зеландия, США, Китай, ужасы, боевик, триллер, WEB-DLRip] Dub (WinMedia)</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=8679101" rel="nofollow" class="topicAuthor">порошков</a>
+								</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>299</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>80</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6873100" rel="nofollow" class="small f-dl dl-stub">1.46&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">13</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>1,813</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-23 13:33</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=22120714" rel="nofollow">tavovic</a>			<a href="viewtopic.php?p=89303231#89303231" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6872645" class="hl-tr" data-topic_id="6872645">
+	<td id="6872645" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6872645" href="viewtopic.php?t=6872645" class="torTopic bold tt-text">Укротитель шторма: Легенда о молотоглавом<wbr> / The Islander / Storm Rider: Legend of Hammerhead (Зоран Лисинац / Zoran Lisinac, Домагой Мазуран / Domagoj Mazuran) [2026, Хорватия, США, Великобритан<wbr>ия, фантастика, боевик, приключения,<wbr> WEB-DLRip] Dub (OKKO)</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=8679101" rel="nofollow" class="topicAuthor">порошков</a>
+								</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>124</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>10</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6872645" rel="nofollow" class="small f-dl dl-stub">1.46&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">12</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>1,044</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-23 12:08</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=30434898" rel="nofollow">victor_1971</a>			<a href="viewtopic.php?p=89303001#89303001" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6866810" class="hl-tr" data-topic_id="6866810">
+	<td id="6866810" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6866810" href="viewtopic.php?t=6866810" class="torTopic bold tt-text">Хокум / Hokum (Дэмиэн Маккарти / Damian McCarthy) [2026, Ирландия, ОАЭ, США, Ужасы, WEB-DLRip-AV<wbr>C] Dub (HDrezka Studio 18+) + Sub (Rus, Eng) + Original Eng</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=697078" rel="nofollow" class="topicAuthor">cocka1</a>
+						<span class="topicPG">&nbsp;[<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1" alt=""> <a href="viewtopic.php?t=6866810"  rel="nofollow">1</a>, <a href="viewtopic.php?t=6866810&amp;start=30"  rel="nofollow">2</a>, <a href="viewtopic.php?t=6866810&amp;start=60"  rel="nofollow">3</a> ]</span>		</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>1009</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>61</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6866810" rel="nofollow" class="small f-dl dl-stub">2.13&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">63</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>10,337</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-23 10:11</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=12459820" rel="nofollow">gamebalance</a>			<a href="viewtopic.php?p=89302760#89302760" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6822537" class="hl-tr" data-topic_id="6822537">
+	<td id="6822537" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6822537" href="viewtopic.php?t=6822537" class="torTopic bold tt-text">Блеф / The Bluff (Фрэнк Э. Флауэрс / Frank E. Flowers) [2026, США, боевик, WEB-DLRip-AV<wbr>C] Dub</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=23770535" rel="nofollow" class="topicAuthor">_ivanes</a>
+						<span class="topicPG">&nbsp;[<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1" alt=""> <a href="viewtopic.php?t=6822537"  rel="nofollow">1</a>, <a href="viewtopic.php?t=6822537&amp;start=30"  rel="nofollow">2</a>, <a href="viewtopic.php?t=6822537&amp;start=60"  rel="nofollow">3</a> ]</span>		</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>318</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>13</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6822537" rel="nofollow" class="small f-dl dl-stub">1.49&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">61</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>11,222</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-23 08:41</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=24011337" rel="nofollow">andy.andy</a>			<a href="viewtopic.php?p=89302588#89302588" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6870314" class="hl-tr" data-topic_id="6870314">
+	<td id="6870314" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6870314" href="viewtopic.php?t=6870314" class="torTopic bold tt-text">Проклятый рыцарь / The Dreadful (Наташа Кермани / Natasha Kermani) [2026, Великобритан<wbr>ия, ужасы, фантастика, боевик, WEB-DLRip] Dub (Невафильм)</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=8679101" rel="nofollow" class="topicAuthor">порошков</a>
+						<span class="topicPG">&nbsp;[<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1" alt=""> <a href="viewtopic.php?t=6870314"  rel="nofollow">1</a>, <a href="viewtopic.php?t=6870314&amp;start=30"  rel="nofollow">2</a> ]</span>		</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>272</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>21</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6870314" rel="nofollow" class="small f-dl dl-stub">1.45&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">38</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>3,061</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-22 23:46</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=15363857" rel="nofollow">germaniy</a>			<a href="viewtopic.php?p=89301986#89301986" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6860505" class="hl-tr" data-topic_id="6860505">
+	<td id="6860505" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6860505" href="viewtopic.php?t=6860505" class="torTopic bold tt-text">Мумия / The Mummy / Lee Cronin's The Mummy (Ли Кронин / Lee Cronin) [2026, США, Ирландия, Испания, Канада, Ужасы, WEB-DLRip-AV<wbr>C] MVO + Sub (Rus, Eng) + Original Eng</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=697078" rel="nofollow" class="topicAuthor">cocka1</a>
+								</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>211</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>9</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6860505" rel="nofollow" class="small f-dl dl-stub">2.2&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">26</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>4,345</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-22 22:24</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=824810" rel="nofollow">shurale</a>			<a href="viewtopic.php?p=89301788#89301788" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6837448" class="hl-tr" data-topic_id="6837448">
+	<td id="6837448" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6837448" href="viewtopic.php?t=6837448" class="torTopic bold tt-text">Взлом на миллион / Wardriver (Ребекка Томас / Rebecca Thomas) [2026, США, триллер, WEB-DLRip] Dub (Pride Production)</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=8679101" rel="nofollow" class="topicAuthor">порошков</a>
+						<span class="topicPG">&nbsp;[<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1" alt=""> <a href="viewtopic.php?t=6837448"  rel="nofollow">1</a> .. <a href="viewtopic.php?t=6837448&amp;start=60"  rel="nofollow">3</a>, <a href="viewtopic.php?t=6837448&amp;start=90"  rel="nofollow">4</a> ]</span>		</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>277</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>32</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6837448" rel="nofollow" class="small f-dl dl-stub">1.45&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">94</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>3,315</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-22 14:24</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=18016324" rel="nofollow">nhbbrcf</a>			<a href="viewtopic.php?p=89300510#89300510" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6844817" class="hl-tr" data-topic_id="6844817">
+	<td id="6844817" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6844817" href="viewtopic.php?t=6844817" class="torTopic bold tt-text">Калевала: Первый викинг / Kalevala: Kullervon tarina / Kalevala: The Story of Kullervo (Антти Йокинен / Antti J. Jokinen) [2026, Финляндия, Фэнтези, драма, история, WEB-DLRip] Dub (Велес)</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=697078" rel="nofollow" class="topicAuthor">cocka1</a>
+						<span class="topicPG">&nbsp;[<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1" alt=""> <a href="viewtopic.php?t=6844817"  rel="nofollow">1</a> .. <a href="viewtopic.php?t=6844817&amp;start=60"  rel="nofollow">3</a>, <a href="viewtopic.php?t=6844817&amp;start=90"  rel="nofollow">4</a> ]</span>		</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>213</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>8</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6844817" rel="nofollow" class="small f-dl dl-stub">1.46&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">104</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>8,365</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-22 13:04</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=537466" rel="nofollow">alex_ao_777</a>			<a href="viewtopic.php?p=89300350#89300350" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6840343" class="hl-tr" data-topic_id="6840343">
+	<td id="6840343" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6840343" href="viewtopic.php?t=6840343" class="torTopic bold tt-text">Полный такос / Operation Taco Gary's (Майкл Квамме / Michael Kvamme) [2026, США, фантастика, комедия, боевик, приключения,<wbr> WEB-DLRip] [Локализованн<wbr>ый видеоряд] Dub (MOYGOLOS)</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=8679101" rel="nofollow" class="topicAuthor">порошков</a>
+						<span class="topicPG">&nbsp;[<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1" alt=""> <a href="viewtopic.php?t=6840343"  rel="nofollow">1</a>, <a href="viewtopic.php?t=6840343&amp;start=30"  rel="nofollow">2</a> ]</span>		</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>184</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>18</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6840343" rel="nofollow" class="small f-dl dl-stub">1.45&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">57</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>7,615</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-22 12:37</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=13526393" rel="nofollow">Guculis555</a>			<a href="viewtopic.php?p=89300289#89300289" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6868218" class="hl-tr" data-topic_id="6868218">
+	<td id="6868218" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6868218" href="viewtopic.php?t=6868218" class="torTopic bold tt-text">Мортал Комбат 2 / Mortal Kombat II (Саймон Маккуойд / Simon McQuoid) [2026, США, фэнтези, боевик, фантастика, WEB-DLRip-AV<wbr>C] Dub (Movie Dubbing) + Original Eng + Sub Rus, Eng</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=23770535" rel="nofollow" class="topicAuthor">_ivanes</a>
+								</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>316</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>38</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6868218" rel="nofollow" class="small f-dl dl-stub">2.62&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">8</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>3,092</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-22 12:26</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=4230558" rel="nofollow">vanvin</a>			<a href="viewtopic.php?p=89300268#89300268" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6855595" class="hl-tr" data-topic_id="6855595">
+	<td id="6855595" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6855595" href="viewtopic.php?t=6855595" class="torTopic bold tt-text">Вот это драма! / The Drama (Кристоффер Боргли / Kristoffer Borgli) [2026, США, драма, мелодрама, комедия, WEB-DLRip-AV<wbr>C] MVO (HDRezka Studio) + Sub Rus, Eng + Original Eng</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=43026051" rel="nofollow" class="topicAuthor">vitolinform</a>
+						<span class="topicPG">&nbsp;[<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1" alt=""> <a href="viewtopic.php?t=6855595"  rel="nofollow">1</a> .. <a href="viewtopic.php?t=6855595&amp;start=60"  rel="nofollow">3</a>, <a href="viewtopic.php?t=6855595&amp;start=90"  rel="nofollow">4</a> ]</span>		</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>943</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>43</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6855595" rel="nofollow" class="small f-dl dl-stub">2.34&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">90</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>20,067</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-22 07:57</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=27584890" rel="nofollow">lia4000</a>			<a href="viewtopic.php?p=89299740#89299740" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6867675" class="hl-tr" data-topic_id="6867675">
+	<td id="6867675" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6867675" href="viewtopic.php?t=6867675" class="torTopic bold tt-text">Плохие соседи / Соседская вражда / Grannfejden / Bad Neighbours (Ульф Мальмрос / Ulf Malmros) [2026, Швеция, комедия, WEB-DLRip-AV<wbr>C] MVO (MUZOBOZ) + Sub Rus, Eng, Swe, Fin, Dan, Nor + Original Swe</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=43026051" rel="nofollow" class="topicAuthor">vitolinform</a>
+								</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>183</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>13</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6867675" rel="nofollow" class="small f-dl dl-stub">1.63&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">16</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>2,531</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-21 22:02</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=15001939" rel="nofollow">morric</a>			<a href="viewtopic.php?p=89298849#89298849" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6859253" class="hl-tr" data-topic_id="6859253">
+	<td id="6859253" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6859253" href="viewtopic.php?t=6859253" class="torTopic bold tt-text">Пёс и я / Hond &amp; ik / I Call Him Dog (Рейнир Смит / Reinier Smit) [2026, Нидерланды, комедия, WEB-DLRip-AV<wbr>C] MVO (MUZOBOZ) + Sub Rus + Original Dut</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=43026051" rel="nofollow" class="topicAuthor">vitolinform</a>
+						<span class="topicPG">&nbsp;[<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1" alt=""> <a href="viewtopic.php?t=6859253"  rel="nofollow">1</a>, <a href="viewtopic.php?t=6859253&amp;start=30"  rel="nofollow">2</a> ]</span>		</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>149</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>10</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6859253" rel="nofollow" class="small f-dl dl-stub">1.48&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">34</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>3,113</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-21 21:19</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=5720694" rel="nofollow">mogvay</a>			<a href="viewtopic.php?p=89298703#89298703" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6868198" class="hl-tr" data-topic_id="6868198">
+	<td id="6868198" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6868198" href="viewtopic.php?t=6868198" class="torTopic bold tt-text">Сначала дамы / Дамы вперед / Ladies First (Теа Шэррок / Thea Sharrock) [2026, США, Комедия, WEB-DLRip] Dub (WinMedia) + Sub (Rus, Eng)</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=697078" rel="nofollow" class="topicAuthor">cocka1</a>
+								</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>385</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>24</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6868198" rel="nofollow" class="small f-dl dl-stub">1.46&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">24</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>4,675</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-21 20:43</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=13371069" rel="nofollow">doomboy</a>			<a href="viewtopic.php?p=89298576#89298576" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6871068" class="hl-tr" data-topic_id="6871068">
+	<td id="6871068" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6871068" href="viewtopic.php?t=6871068" class="torTopic bold tt-text">То, что не было сказано / Le cose non dette / The Things Left Unspoken / Things Unspoken (Габриэле Муччино / Gabriele Muccino) [2026, Италия, драма, HDRip-AVC] MVO (AlphaProjec<wbr>t) + Sub Rus, Ita + Original Ita</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=43026051" rel="nofollow" class="topicAuthor">vitolinform</a>
+								</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>310</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>24</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6871068" rel="nofollow" class="small f-dl dl-stub">1.87&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">11</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>3,557</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-21 20:33</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=14287747" rel="nofollow">Dimeik</a>			<a href="viewtopic.php?p=89298540#89298540" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6859941" class="hl-tr" data-topic_id="6859941">
+	<td id="6859941" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6859941" href="viewtopic.php?t=6859941" class="torTopic bold tt-text">Мортал Комбат 2 / Mortal Kombat II (Саймон Маккуойд / Simon McQuoid) [2026, США, фэнтези, боевик, фантастика, WEB-DLRip] Dub (Movie Dubbing)</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=8679101" rel="nofollow" class="topicAuthor">порошков</a>
+						<span class="topicPG">&nbsp;[<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1" alt=""> <a href="viewtopic.php?t=6859941"  rel="nofollow">1</a> .. <a href="viewtopic.php?t=6859941&amp;start=180"  rel="nofollow">7</a>, <a href="viewtopic.php?t=6859941&amp;start=210"  rel="nofollow">8</a> ]</span>		</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>252</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>13</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6859941" rel="nofollow" class="small f-dl dl-stub">1.45&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">224</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>3,823</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-21 19:33</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=16921300" rel="nofollow">lagblank</a>			<a href="viewtopic.php?p=89298327#89298327" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6852730" class="hl-tr" data-topic_id="6852730">
+	<td id="6852730" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6852730" href="viewtopic.php?t=6852730" class="torTopic bold tt-text">Вершина / Apex (Бальтасар Кормакур / Baltasar Korm&#225;kur) [2026, Канада, Австралия, США, Исландия, боевик, триллер, WEB-DLRip-AV<wbr>C] Dub (WinMedia) + Original Eng + Sub Rus, Eng</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=23770535" rel="nofollow" class="topicAuthor">_ivanes</a>
+						<span class="topicPG">&nbsp;[<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1" alt=""> <a href="viewtopic.php?t=6852730"  rel="nofollow">1</a> .. <a href="viewtopic.php?t=6852730&amp;start=60"  rel="nofollow">3</a>, <a href="viewtopic.php?t=6852730&amp;start=90"  rel="nofollow">4</a> ]</span>		</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>1079</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>41</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6852730" rel="nofollow" class="small f-dl dl-stub">1.98&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">99</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>24,876</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-21 17:26</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=13276841" rel="nofollow">фонь_КА</a>			<a href="viewtopic.php?p=89297900#89297900" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6863406" class="hl-tr" data-topic_id="6863406">
+	<td id="6863406" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6863406" href="viewtopic.php?t=6863406" class="torTopic bold tt-text">Мать Мария / Mother Mary (Дэвид Лоури / David Lowery) [2026, Великобритан<wbr>ия, Финляндия, Германия, США, драма, музыка, ужасы, WEB-DLRip] Dub (WinMedia)</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=8679101" rel="nofollow" class="topicAuthor">порошков</a>
+								</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>57</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>4</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6863406" rel="nofollow" class="small f-dl dl-stub">1.46&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">17</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>1,238</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-21 16:06</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=20703334" rel="nofollow">A1968</a>			<a href="viewtopic.php?p=89297665#89297665" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6858950" class="hl-tr" data-topic_id="6858950">
+	<td id="6858950" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6858950" href="viewtopic.php?t=6858950" class="torTopic bold tt-text">Они придут за тобой / They Will Kill You (Кирилл Соколов / Kirill Sokolov) [2026, ЮАР, США, Канада, Комедия, ужасы, WEB-DLRip-AV<wbr>C] Dub (WinMedia) + Sub (Rus, Eng) + Original Eng</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=697078" rel="nofollow" class="topicAuthor">cocka1</a>
+								</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>197</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>13</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6858950" rel="nofollow" class="small f-dl dl-stub">1.41&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">15</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>3,273</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-21 15:48</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=15231140" rel="nofollow">luckypunch110</a>			<a href="viewtopic.php?p=89297614#89297614" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6818802" class="hl-tr" data-topic_id="6818802">
+	<td id="6818802" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6818802" href="viewtopic.php?t=6818802" class="torTopic bold tt-text">Казнить нельзя помиловать / Mercy (Тимур Бекмамбетов / Timur Bekmambetov)<wbr> [2026, США, Россия, фантастика, боевик, триллер, драма, криминал, детектив, WEB-DLRip-AV<wbr>C] Dub (WinMedia)</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=23770535" rel="nofollow" class="topicAuthor">_ivanes</a>
+						<span class="topicPG">&nbsp;[<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1" alt=""> <a href="viewtopic.php?t=6818802"  rel="nofollow">1</a> .. <a href="viewtopic.php?t=6818802&amp;start=180"  rel="nofollow">7</a>, <a href="viewtopic.php?t=6818802&amp;start=210"  rel="nofollow">8</a> ]</span>		</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>747</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>23</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6818802" rel="nofollow" class="small f-dl dl-stub">1.47&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">224</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>26,570</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-21 15:16</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=11035025" rel="nofollow">kingsize777</a>			<a href="viewtopic.php?p=89297531#89297531" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6870321" class="hl-tr" data-topic_id="6870321">
+	<td id="6870321" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6870321" href="viewtopic.php?t=6870321" class="torTopic bold tt-text">Флавия. Юный детектив / Flavia (Бхарат Наллури / Bharat Nalluri) [2026, США, Великобритан<wbr>ия, комедия, детектив, приключения,<wbr> семейный, WEB-DLRip] [Локализованн<wbr>ый видеоряд] Dub</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=8679101" rel="nofollow" class="topicAuthor">порошков</a>
+								</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>337</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>13</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6870321" rel="nofollow" class="small f-dl dl-stub">1.46&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">18</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>2,621</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-21 11:18</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=21069168" rel="nofollow">igsoch</a>			<a href="viewtopic.php?p=89296771#89296771" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6849175" class="hl-tr" data-topic_id="6849175">
+	<td id="6849175" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6849175" href="viewtopic.php?t=6849175" class="torTopic bold tt-text">Наследник / How to Make a Killing (Джон Паттон Форд / John Patton Ford) [2026, Великобритан<wbr>ия, Франция, Триллер, комедия, криминал, WEB-DLRip] Dub (Мосфильм-Ма<wbr>стер)</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=5155021" rel="nofollow" class="topicAuthor">Сибиряк777</a>
+						<span class="topicPG">&nbsp;[<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1" alt=""> <a href="viewtopic.php?t=6849175"  rel="nofollow">1</a>, <a href="viewtopic.php?t=6849175&amp;start=30"  rel="nofollow">2</a> ]</span>		</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>367</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>18</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6849175" rel="nofollow" class="small f-dl dl-stub">1.46&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">33</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>11,136</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-15 17:45</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=15633044" rel="nofollow">jerkyporky</a>			<a href="viewtopic.php?p=89279015#89279015" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6823272" class="hl-tr" data-topic_id="6823272">
+	<td id="6823272" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6823272" href="viewtopic.php?t=6823272" class="torTopic bold tt-text">Одна миля: Глава первая / One Mile: Chapter One (Адам Дэвидсон / Adam Davidson) [2026, США, боевик, триллер, драма, приключения,<wbr> WEB-DLRip-AV<wbr>C] MVO (MUZOBOZ) + Sub Eng + Original Eng</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=43026051" rel="nofollow" class="topicAuthor">vitolinform</a>
+						<span class="topicPG">&nbsp;[<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1" alt=""> <a href="viewtopic.php?t=6823272"  rel="nofollow">1</a>, <a href="viewtopic.php?t=6823272&amp;start=30"  rel="nofollow">2</a> ]</span>		</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>144</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>9</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6823272" rel="nofollow" class="small f-dl dl-stub">1.93&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">35</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>9,626</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-03-14 15:17</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=4757098" rel="nofollow">udrees</a>			<a href="viewtopic.php?p=88944782#88944782" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6856667" class="hl-tr" data-topic_id="6856667">
+	<td id="6856667" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6856667" href="viewtopic.php?t=6856667" class="torTopic bold tt-text">Проект «Конец света» / Project Hail Mary (Фил Лорд / Phil Lord, Кристофер Миллер / Christopher Miller) [2026, США, фантастика, триллер, драма, WEB-DLRip-AV<wbr>C] [IMAX] Dub (MovieDalen)<wbr> + Sub (Rus, eng) + Original (Eng)</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=43748518" rel="nofollow" class="topicAuthor">JNS82</a>
+						<span class="topicPG">&nbsp;[<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1" alt=""> <a href="viewtopic.php?t=6856667"  rel="nofollow">1</a>, <a href="viewtopic.php?t=6856667&amp;start=30"  rel="nofollow">2</a> ]</span>		</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>573</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>53</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6856667" rel="nofollow" class="small f-dl dl-stub">3.31&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">40</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>10,243</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-20 22:54</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=3000884" rel="nofollow">Manichaean</a>			<a href="viewtopic.php?p=89295505#89295505" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6843383" class="hl-tr" data-topic_id="6843383">
+	<td id="6843383" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6843383" href="viewtopic.php?t=6843383" class="torTopic bold tt-text">Проект «Конец света» / Project Hail Mary (Фил Лорд / Phil Lord, Кристофер Миллер / Christopher Miller) [2026, США, фантастика, триллер, драма, WEB-DLRip] Dub (MovieDalen)<wbr></a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=8937548" rel="nofollow" class="topicAuthor">Бла-бла бла</a>
+						<span class="topicPG">&nbsp;[<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1" alt=""> <a href="viewtopic.php?t=6843383"  rel="nofollow">1</a>, <a href="viewtopic.php?t=6843383&amp;start=30"  rel="nofollow">2</a> ]</span>		</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>504</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>42</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6843383" rel="nofollow" class="small f-dl dl-stub">3.45&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">43</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>16,097</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-05 22:42</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=35463" rel="nofollow">iamdmn</a>			<a href="viewtopic.php?p=89251508#89251508" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6840345" class="hl-tr" data-topic_id="6840345">
+	<td id="6840345" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6840345" href="viewtopic.php?t=6840345" class="torTopic bold tt-text">Ешь, молись, рычи / Ешь, молись, лай / Eat Pray Bark (Марко Петри / Marco Petry) [2026, Германия, комедия, WEB-DLRip-AV<wbr>C] Dub (VideoFilm) + Sub Rus, Eng, Ukr, Deu, Fra + Original Deu</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=43026051" rel="nofollow" class="topicAuthor">vitolinform</a>
+								</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>33</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>2</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6840345" rel="nofollow" class="small f-dl dl-stub">2.01&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">25</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>1,400</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-05-31 03:44</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=50276871" rel="nofollow">Mentalsky</a>			<a href="viewtopic.php?p=89234780#89234780" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6845772" class="hl-tr" data-topic_id="6845772">
+	<td id="6845772" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6845772" href="viewtopic.php?t=6845772" class="torTopic bold tt-text">Невеста! / The Bride! (Мэгги Джилленхол / Maggie Gyllenhaal) [2026, США, Франция, фантастика, драма, мелодрама, WEB-DLRip-AV<wbr>C] Dub (Movie Dubbing) + Original Eng + Sub Rus, Eng</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=23770535" rel="nofollow" class="topicAuthor">_ivanes</a>
+								</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>108</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>6</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6845772" rel="nofollow" class="small f-dl dl-stub">2.22&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">13</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>3,382</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-07 11:43</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=1479378" rel="nofollow">NeuronViking</a>			<a href="viewtopic.php?p=89255575#89255575" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6870449" class="hl-tr" data-topic_id="6870449">
+	<td id="6870449" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6870449" href="viewtopic.php?t=6870449" class="torTopic bold tt-text">Я иду искать 2 / Ready or Not 2: Here I Come (Мэтт Беттинелли-О<wbr>лпин / Matt Bettinelli-O<wbr>lpin, Тайлер Джиллетт / Tyler Gillett) [2026, США, Канада, ужасы, триллер, комедия, WEB-DLRip] AVO (Андрей Дольский)</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=26521472" rel="nofollow" class="topicAuthor">Leonard Lew</a>
+								</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>35</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>7</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6870449" rel="nofollow" class="small f-dl dl-stub">2.05&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">5</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>618</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-17 18:51</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=33832632" rel="nofollow">aleviko</a>			<a href="viewtopic.php?p=89284818#89284818" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6832240" class="hl-tr" data-topic_id="6832240">
+	<td id="6832240" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6832240" href="viewtopic.php?t=6832240" class="torTopic bold tt-text">Крик 7 / Scream 7 (Кевин Уильямсон / Kevin Williamson) [2026, США, Канада, ужасы, детектив, WEB-DLRip] Dub (Продубляж)</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=8679101" rel="nofollow" class="topicAuthor">порошков</a>
+								</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>63</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>3</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6832240" rel="nofollow" class="small f-dl dl-stub">1.46&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">8</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>2,801</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-04-25 20:47</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=32015936" rel="nofollow">DolbyDobson</a>			<a href="viewtopic.php?p=89111416#89111416" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6827543" class="hl-tr" data-topic_id="6827543">
+	<td id="6827543" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6827543" href="viewtopic.php?t=6827543" class="torTopic bold tt-text">Зараза / Cold Storage (Джонни Кэмпбелл / Jonny Campbell) [2026, Франция, США, ужасы, фантастика, комедия, WEB-DLRip] MVO (LE-Producti<wbr>on)</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=17075177" rel="nofollow" class="topicAuthor">7turza</a>
+						<span class="topicPG">&nbsp;[<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1" alt=""> <a href="viewtopic.php?t=6827543"  rel="nofollow">1</a> .. <a href="viewtopic.php?t=6827543&amp;start=60"  rel="nofollow">3</a>, <a href="viewtopic.php?t=6827543&amp;start=90"  rel="nofollow">4</a> ]</span>		</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>571</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>29</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6827543" rel="nofollow" class="small f-dl dl-stub">1.46&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">95</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>25,526</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-06-09 10:27</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=23063814" rel="nofollow">kz6000</a>			<a href="viewtopic.php?p=89260707#89260707" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr id="tr-6823772" class="hl-tr" data-topic_id="6823772">
+	<td id="6823772" class="vf-col-icon vf-topic-icon-cell">
+		<img class="topic_icon" src="https://static.rutracker.cc/templates/v1/images/folder_dl.gif" alt="">
+			</td>
+
+	<td class="vf-col-t-title tt" style="padding: 3px 5px 3px 3px;">
+						<div class="torTopic">
+									<span class="tor-icon tor-approved">&radic;</span>&#0183;												<a id="tt-6823772" href="viewtopic.php?t=6823772" class="torTopic bold tt-text">28 лет спустя: Часть II. Храм костей / 28 Years Later: The Bone Temple (Ниа ДаКоста / Nia DaCosta) [2026, Великобритан<wbr>ия, США, ужасы, WEB-DLRip] Dub (MovieDalen)<wbr> + Sub (Rus, Eng) + Original Eng</a>
+					</div>
+		<div class="topicAuthor" style="padding-top: 2px;">
+						<a href="profile.php?mode=viewprofile&amp;u=8679101" rel="nofollow" class="topicAuthor">порошков</a>
+								</div>
+	</td>
+
+	<td class="vf-col-tor tCenter med nowrap" style="padding: 2px 4px;">
+				<div>
+			<div>
+				<span class="seedmed" title="Seeders"><b>125</b></span><span class="med"> | </span><span class="leechmed" title="Leechers"><b>11</b></span>
+			</div>
+			<div style="padding-top: 2px" class="small">
+				<a href="dl.php?t=6823772" rel="nofollow" class="small f-dl dl-stub">2.18&nbsp;GB</a>			</div>
+		</div>
+			</td>
+
+	<td class="vf-col-replies tCenter small nowrap" style="padding: 3px 4px 2px;">
+		<p>
+			<span title="Ответов">17</span>
+		</p>
+				<p style="padding-top: 2px" class="med" title="Торрент скачан">
+			<b>4,880</b>
+		</p>
+			</td>
+
+	<td class="vf-col-last-post tCenter small nowrap" style="padding: 3px 6px 2px;">
+		<p>2026-04-18 21:58</p>
+		<p style="padding-top: 2px">
+			<a href="profile.php?mode=viewprofile&amp;u=52144896" rel="nofollow">maxim_rnd7</a>			<a href="viewtopic.php?p=89085404#89085404" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/icon_latest_reply.gif" class="icon2" alt="&raquo;"></a>
+		</p>
+	</td>
+</tr>
+<tr>
+	<td colspan="5" class="row2 med pad_4 tCenter input-buttons">
+				&nbsp;
+			</td>
+</tr>
+</table>
+
+
+<table class="w100 pad_2">
+<tr>
+	<td><a href="posting.php?f=252&amp;mode=newtopic" rel="nofollow"><img src="https://static.rutracker.cc/templates/v1/images/post.gif" alt="Новая тема"></a></td>
+	<td class="nav w100">
+		&nbsp;<a href="index.php">Главная</a>
+		<em>&raquo;</em> <a href="index.php?c=2" rel="nofollow">Кино, Видео и ТВ</a>
+		<em>&raquo;</em>&nbsp;<a href="viewforum.php?f=7">Зарубежное кино</a>		<em>&raquo;</em>&nbsp;<a href="viewforum.php?f=252">Фильмы 2026</a>
+	</td>
+</tr>
+</table>
+
+<div class="bottom_info pad_2">
+
+		<div id="pagination" class="nav clearfix">
+		<p style="float: left">Страница <b>1</b> из <b>5</b></p>
+		<p style="float: right"><span class="pg-jump-menu"><a class="menu-root" href="#pg-jump" onclick="BB.focus_pg_input();">Страницы</a> :&nbsp;&nbsp;</span><b>1</b>, <a class="pg" href="viewforum.php?f=252&amp;start=50">2</a>, <a class="pg" href="viewforum.php?f=252&amp;start=100">3</a>, <a class="pg" href="viewforum.php?f=252&amp;start=150">4</a>, <a class="pg" href="viewforum.php?f=252&amp;start=200">5</a>&nbsp;&nbsp;<a class="pg" href="viewforum.php?f=252&amp;start=50">След.</a></p>
+	</div>
+	
+	<div class="tRight">
+		<span id="jumpbox-wrap"></span>
+	</div>
+
+	</div><!--/bottom_info-->
+
+				</div><!--/main_content_wrap-->
+			</td><!--/main_content-->
+
+		</tr>
+		</table>
+	</div><!--/page_content-->
+
+	<!--page_footer-->
+	<div id="page_footer" class="hide-for-print">
+
+		
+		<div class="clear"></div>
+
+		<nav id="footer-info-links">
+			<div>
+				<a href="info.php?show=user_agreement" rel="nofollow">Условия использования</a>
+				&middot;
+				<a href="info.php?show=advert" rel="nofollow">Реклама на сайте</a>
+				&middot;
+				<a href="info.php?show=copyright_holders" rel="nofollow">Для правообладателей</a>
+				&middot;
+				<a href="info.php?show=press" rel="nofollow">Для прессы</a>
+				&middot;
+				<a href="viewtopic.php?t=2234744">Для провайдеров</a>
+				<!--&middot;-->
+				<!--<a href="http://rutracker.news">Блог</a>-->
+				&middot;
+				<a href="https://rutracker.wiki">Торрентопедия</a>
+			</div>
+			<div>
+				<a href="viewtopic.php?t=1045"><b>Правила</b></a>
+				&middot;
+				<a href="/go/8" rel="nofollow">Кому задать вопрос</a>
+				&middot;
+				<a href="viewforum.php?f=1538">Авторские раздачи</a>
+				&middot;
+				<a href="viewforum.php?f=1289">Конкурсы</a>
+				&middot;
+				<a href="viewforum.php?f=2332">Новости &quot;Хранителей&quot; и &quot;Антикваров&quot;</a>
+				&middot;
+				<a href="#" onclick="return post2url('index.php', {rand_rel: 1});" rel="nofollow">Случайная раздача</a>
+			</div>
+		</nav>
+
+		
+		<div class="tCenter nowrap" style="margin: 18px 4px 4px 4px;">
+								</div>
+
+		<div class="footer-bottom-links">
+			<ul class="inlined middot-separated">
+				<li><a href="groupcp.php?g=104792" rel="nofollow" target="_blank">Администрация</a></li>
+				<li><a href="groupcp.php?g=104787" rel="nofollow" target="_blank">Модераторы</a></li>
+				<li><a href="groupcp.php?g=104841" rel="nofollow" target="_blank">Тех. помощь</a></li>
+				<li><a href="https://t.me/rutracker_news" rel="nofollow" target="_blank">Telegram-канал</a></li>
+			</ul>
+			<div class="wide">
+									<script>
+					$(function () {
+						var title = "";
+						var src = "https://counter.yadro.ru/hit?t44.1;r" + encodeURIComponent(document.referrer) +
+							((typeof (screen) == "undefined") ? "" : ";s" + screen.width + "*" + screen.height + "*" + (screen.colorDepth ? screen.colorDepth : screen.pixelDepth)) +
+							";u" + encodeURIComponent(document.URL) + ";h" + encodeURIComponent(title.substring(0, 80)) + ";" + Math.random();
+						$('<img src="' + src + '" alt="">').on('load', function () {
+							$('#liveinternet').append(this);
+						});
+					});
+					</script>
+					<a id="liveinternet" href="https://www.liveinternet.ru/stat/rutracker.org/index.html?lang=ru" target="_blank"></a>
+							</div>
+			<ul class="inlined middot-separated">
+																							</ul>
+		</div>
+
+	</div><!--/page_footer-->
+</div><!--/page_container-->
+
+
+<div id="ajax-loading"><b>Loading...</b></div>
+<div id="ajax-error"><b>Error</b></div>
+<style>
+#bb-alert-box {
+	width: auto;
+	max-width: 800px;
+	line-height: 18px;
+	display: none;
+}
+#bb-alert-msg {
+	min-width: 400px;
+	max-height: 400px;
+	margin: 50px 20px;
+	padding: 10px;
+	overflow: auto;
+	text-align: center;
+}
+.bb-alert-err {
+	color: #7E0000;
+	background: #FFEEEE;
+	box-shadow: 0 0 20px #B85353;
+	font-weight: bold;
+}
+</style>
+<div id="bb-alert-box">
+	<div id="bb-alert-msg"></div>
+</div>
+<div id="modal-blocker"></div>
+
+<script>
+$(function () {
+	if (!BB.hasET() && BB.getUrlParam('view') !== 'print') {
+		BB.navbar.init();
+	}
+});
+</script>
+<div id="nav-panel" class="nav-hidden-arrow hide-for-print">
+	<div id="nav-up" class="nav-btn" title="Вверх">
+		<span class="nav-icon"></span>
+	</div>
+	<div id="nav-settings" class="nav-btn">
+		<span class="nav-icon" title="Настройки"></span>
+		<ul id="nav-opt-menu">
+			<li class="nav-event" data-event="click">Показывать по клику</li>
+			<li class="nav-event" data-event="mouseenter">Показывать по наведению</li>
+		</ul>
+	</div>
+	<div id="nav-down" class="nav-btn" title="Вниз">
+		<span class="nav-icon"></span>
+	</div>
+	<div class="nav-hidden-overlay"></div>
+</div>
+
+	</div><!--/body_container-->
+
+<script>(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML="window.__CF$cv$params={r:'a10650f36e39f5d7',t:'MTc4MjI0NzMxNA=='};var a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);";b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script></body>
+</html>

--- a/core/network/rutracker/src/test/resources/fixtures/comments_page.html
+++ b/core/network/rutracker/src/test/resources/fixtures/comments_page.html
@@ -1,0 +1,2397 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+
+<meta charset="Windows-1251">
+<meta name="robots" content="nofollow">
+	<link rel="canonical" href="https://rutracker.org/forum/viewtopic.php?t=5116006">
+
+<title>Мобильные устройства :: RuTracker.org</title>
+
+<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+<link rel="manifest" href="/manifest.json">
+<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
+<meta name="msapplication-TileColor" content="#2b5797">
+<meta name="msapplication-TileImage" content="/mstile-144x144.png">
+<meta name="theme-color" content="#ffffff">
+
+<link rel="search" type="application/opensearchdescription+xml" title="Поиск на RuTracker.org" href="https://static.rutracker.cc/opensearch.xml">
+
+<script>
+window.BB = {
+	cur_domain: location.hostname.replace(/.*?(([a-z0-9-]+\.){1,2}[a-z0-9-]+)$/, '$1'),
+	form_token: '',
+	opt_js: {},
+
+	IS_GUEST: !!'1',
+	IMG_URL: 'https://static.rutracker.cc/templates/v1/images',
+	SMILES_URL: 'https://static.rutracker.cc/smiles',
+	catId: 36,
+	FORUM_ID: 659,
+	parentForumId: 1958,
+		PG_PER_PAGE: '30',
+	PG_BASE_URL: 'viewtopic.php?t=5116006',
+		COOKIE_MARK: 'bb_mark_read',
+	};
+BB.cookie_defaults = {
+	domain: '.' + BB.cur_domain,
+	path: "/forum/",
+};
+</script>
+<link href="https://static.rutracker.cc/templates/v1/min/eb83350bae3880e4073b81d26294de5d.all.min.css" rel="stylesheet">
+<script src="https://static.rutracker.cc/templates/v1/min/4e695e8ea9cf5a1dcc7aed231b887c51.lib.min.js"></script>
+<script src="https://static.rutracker.cc/templates/v1/min/3b60ab3546ba966484df4c3099b918ab.bb.min.js"></script>
+
+
+
+<style>
+.invisible-el {
+	/* @include element-invisible(); */
+	clip: rect(1px, 1px, 1px, 1px);
+	height: 1px;
+	overflow: hidden;
+	position: absolute !important;
+	width: 1px;
+}
+.hidden, .menu-sub, #ajax-loading, #ajax-error, var.ajax-params, #modal-blocker, .q-post {
+	display: none;
+}
+/**/
+#logo {
+	min-height: auto;
+}
+/**/
+/* temp */
+/* temp end */
+</style>
+
+<noscript>
+	<style>
+	.sp-body {
+		display: block; /* for bots */
+	}
+	</style>
+</noscript>
+
+</head>
+
+<body class="" style="">
+
+<div id="invisible-heap" class="invisible-el"></div>
+<div id="preload" class="invisible-el"></div>
+
+<div class="menu-sub" id="pg-jump">
+	<table style="border-spacing: 1px;">
+	<tr>
+		<th style="padding: 2px;">К странице...</th>
+	</tr>
+	<tr>
+		<td style="padding: 2px;">
+			<form onsubmit="BB.go_to_page( $('#pg-page').val() ); return false;">
+				<input id="pg-page" type="text" size="5" maxlength="4">
+				<input type="submit" value="Перейти">
+			</form>
+		</td>
+	</tr>
+	</table>
+</div>
+
+
+<div id="body_container">
+
+		<script>
+	if (top != self && !self.location.hostname.match(BB.allowed_translator_hosts)) {
+		$(function () {
+			$('body').html('<h1 style="text-align: center;"><br><br>Похоже, вас пытаются обмануть<br>frame\'s hostname: ' + self.location.hostname + '</h1>');
+			throw new Error('in frame');
+		});
+	}
+		</script>
+
+	<div id="page_container">
+
+		<div id="page_header" class="hide-for-print">
+
+			<div id="main-nav" class="site-nav clearfix">
+				<ul class="inlined middot-separated floatL">
+					<li>
+						<a href="index.php"><b>Главная</b></a>
+					</li>
+					<li>
+													<a href="tracker.php" rel="nofollow"><b>Трекер</b></a>
+											</li>
+					<li>
+						<a href="search.php" rel="nofollow"><b>Поиск</b></a>
+					</li>
+					<li>
+						<a href="groupcp.php" rel="nofollow"><b>Группы</b></a>
+					</li>
+					<li>
+						<a href="https://rutracker.wiki/" target="_blank"><b>FAQ</b></a>
+					</li>
+					<li>
+						<a href="viewtopic.php?t=6812335" style="color: #7b1fa2;"><b>VPN</b></a>
+					</li>
+					<li>
+						<a href="viewtopic.php?t=1045"><b>Правила</b></a>
+					</li>
+					<li>
+						<a href="viewtopic.php?t=6452965" style="color: #880e4f;"><b>Донаты</b></a>
+					</li>
+									</ul>
+											</div>
+			<!--/main-nav-->
+
+			
+			<div id="logo">
+				<table style="">
+				<tr>
+					<td id="logo-td" style="padding: 3px 7px 3px 15px;">
+						<a href="index.php" class="site-logo-link">
+								<img class="site-logo"
+		src="https://static.rutracker.cc/logo/logo-3.svg"
+		style=""
+		alt="logo">
+							</a>
+					</td>
+					<td class="tCenter w100" style="padding: 6px 10px 0 3px;">
+											</td>
+				</tr>
+				</table>
+			</div>
+			<!--/logo-->
+
+						<div class="topmenu">
+				<table class="w100">
+				<tr>
+					
+					<td class="tCenter pad_2 nowrap">
+						<div>
+															<a href="profile.php?mode=register" rel="nofollow"><b>Регистрация</b></a>
+								&nbsp;&#0183;&nbsp;
+								<a href="#" onclick="BB.toggle_top_login(); return false;" tabindex="5"><b>Вход</b></a>
+
+								<div id="top-login-box">
+									<form id="quick-search-guest" method="get" action="tracker.php">
+										<input id="search-text-guest" type="text" name="nm" value="" tabindex="1" accesskey="q">
+										<input type="submit" value="поиск" tabindex="2">
+									</form>
+									<form id="login-form-quick" method="post" action="login.php" style="display: none;">
+																				<input id="top-login-uname" type="text" name="login_username" tabindex="1" accesskey="l" placeholder="имя">
+										<input id="top-login-pwd" type="password" name="login_password" tabindex="2" placeholder="пароль">
+										<label title="Защищенное соединение" class="login-ssl-block" style="display: none;">
+											<input class="login-ssl" type="checkbox" tabindex="3" checked>SSL
+										</label>
+										<input id="top-login-btn" type="submit" name="login" value="вход" tabindex="4">
+									</form>
+								</div>
+
+								<a href="otp.php" rel="nofollow"><b>Забыли имя или пароль?</b></a>
+													</div>
+					</td>
+
+					
+				</tr>
+				</table>
+			</div><!--/topmenu-->
+			
+			
+		</div>
+		<!--/page_header-->
+
+		
+		<div id="page_content">
+			<table style="width: 100%; border: none;">
+			<tr>
+
+				
+				<td id="main_content">
+					<div id="main_content_wrap">
+
+						
+						
+						
+						
+						<!--/page_header.tpl-->
+
+
+<script>
+$(function () {
+		BB.initMagnetLinks();
+	});
+</script>
+
+
+
+
+<table class="w100">
+<tr>
+	<td class="w100 vBottom pad_2">
+		<h1 class="maintitle">
+			<a id="topic-title" class="topic-title-5116006 highlight-cyrillic" href="https://rutracker.org/forum/viewtopic.php?t=5116006">Мобильные устройства</a>
+		</h1>
+		<div class="small hide-for-print" style="margin: 12px 4px 8px;">
+			<b><span class="pg-jump-menu"><a class="menu-root" href="#pg-jump" onclick="BB.focus_pg_input();">Страницы</a> :&nbsp;&nbsp;</span><b>1</b>, <a class="pg" href="viewtopic.php?t=5116006&amp;start=30">2</a>, <a class="pg" href="viewtopic.php?t=5116006&amp;start=60">3</a> ... <a class="pg" href="viewtopic.php?t=5116006&amp;start=540">19</a>, <a class="pg" href="viewtopic.php?t=5116006&amp;start=570">20</a>, <a class="pg" href="viewtopic.php?t=5116006&amp;start=600">21</a>&nbsp;&nbsp;<a class="pg" href="viewtopic.php?t=5116006&amp;start=30">След.</a></b>
+		</div>
+		
+		<table class="w100">
+		<tr>
+			<td class="pad_2 hide-for-print">
+				<a href="posting.php?mode=reply&amp;t=5116006"><img src="https://static.rutracker.cc/templates/v1/images/reply.gif" alt="Ответить"></a>
+			</td>
+			<td class="nav t-breadcrumb-top w100 pad_2">
+				&nbsp;<a href="index.php?c=36">ОБХОД БЛОКИРОВОК</a>
+								<em>&raquo;</em> <a href="viewforum.php?f=1958">Обход блокировок</a>
+								<em>&raquo;</em> <a href="viewforum.php?f=659">Обход блокировок на мобильных устройствах</a>
+			</td>
+		</tr>
+		</table>
+
+	</td>
+	<td class="pad_2 hide-for-print">
+			</td>
+</tr>
+</table>
+
+
+
+
+
+<table class="topic" id="topic_main">
+<tbody class="hide-for-print">
+<tr>
+	<th colspan="2" class="thHead">
+		<div id="soc-container" data-share_url="https://rutracker.org/forum/viewtopic.php?t=5116006" data-share_title="Мобильные устройства">&nbsp;</div>
+	</th>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_69257117" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="69257117"></a>
+		
+		
+				<p class="nick nick-author">filolya</p>
+		
+		
+				<p class="rank_img"><img class="user-rank" src="https://static.rutracker.cc/ranks/1apr_yshla_v_les.gif" alt="Ушла в лес"></p>		<p class="avatar"><img src="https://static.rutracker.cc/avatars/0/5/227805.gif" alt=""></p>		<p class="joined"><em>Стаж:</em> 19 лет 9 месяцев</p>		<p class="posts"><em>Сообщений:</em> 30014</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">filolya &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?t=5116006">14-Ноя-15 00:13</a>
+				</span>
+												<span class="posted_since hide-for-print">(10 лет 7 месяцев назад, ред. 14-Ноя-15 02:39)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+								
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=69257117">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-1">
+												<div class="post_body" id="p-69257117" data-ext_link_data='{"p":69257117,"t":5116006,"f":659,"u":227805}'>
+													<span class="post-align" style="text-align: center;"><span class="post-b"><span style="font-size: 20px; line-height: normal;">Обход блокировки на мобильных устройствах</span></span></span>
+<div class="sp-wrap">
+<div class="sp-head folded"><span>Андроид</span></div>
+<div class="sp-body">[*]Самый простой способ - использование Турбо-режима в браузерах Chrome (Экономия трафика), Opera , UC Browser (Быстрый режим) и т.п. (включается в настройках). <span class="post-u">После перехода на https данный режим работать у нас не будет!</span>
+<div class="sp-wrap">
+<div class="sp-head folded"><span>пример включения режима в Chrome и UC Browser</span></div>
+<div class="sp-body"><var class="postImg" title="http://rutracker.wiki/images/6/63/2step.png">&#10;</var><var class="postImg" title="http://i65.fastpic.ru/big/2016/0129/90/3d9616ab2df68cda118643249cc0d890.png">&#10;</var></div>
+</div>
+[*] Использование <a href="https://play.google.com/store/apps/details?id=info.guardianproject.orfox&amp;hl=ru" class="postLink">Orfox: Tor Browser for Android</a>
+<div class="sp-wrap">
+<div class="sp-head folded"><span>Настройка OrFox для рутрекера</span></div>
+<div class="sp-body">Нажмите в меню кнопку Noscript и поставьте в открывшемся окне галку напротив rutracker.org<var class="postImg" title="http://i74.fastpic.ru/big/2016/0125/09/76382a529f4b490a55d2fe2ce391ce09.png">&#10;</var></div>
+</div>
+[*] <a href="https://play.google.com/store/apps/details?id=net.bypass.vpn" class="postLink">Cloud VPN</a><br>
+[*] <a href="https://psiphon.ca/ru/download.html" class="postLink">https://psiphon.ca/ru/download.html</a><br>
+[*] <a href="https://play.google.com/store/apps/details?id=com.cloudmosa.puffinFree" class="postLink">Puffin Web Browser</a></div>
+</div>
+<div class="sp-wrap">
+<div class="sp-head folded"><span>iOS</span></div>
+<div class="sp-body">[*]<a href="https://itunes.apple.com/ru/app/onion-browser/id519296448?mt=8" class="postLink">Onion Browser</a><br>
+[*]<a href="https://itunes.apple.com/ru/app/browsec-vpn-internet-privacy/id978583103?mt=8" class="postLink">Browsec VPN</a><br>
+[*] Сервис <a href="https://www.tunnelbear.com/" class="postLink">https://www.tunnelbear.com/</a><br>
+[*] <a href="http://antizapret.prostovpn.org/" class="postLink">http://antizapret.prostovpn.org/</a></div>
+</div>
+Обход блокировки серверов статистики обсуждается в теме <a href="viewtopic.php?t=5134313" class="postLink"><span class="post-b">Обход блокировки bt*. трекеров (основные инструкции)</span></a><hr class="post-hr"><hr class="post-hr"><hr class="post-hr">
+<div class="q-wrap">
+<div class="q-head"><span><b>dark_timur</b> писал(а):</span></div>
+<div class="q"><u class="q-post">69838069</u><span class="post-b">Итак, пока не стало слишком поздно, я хочу за администрацию централизировать все известные на данный момент методы обхода для мобильных устройств.</span><br>
+Если не получается, не работает или сложно - пробуйте следующий метод. Некоторые методы могут быть проще, некоторые - сложнее.
+<div class="sp-wrap">
+<div class="sp-head folded"><span>Android</span></div>
+<div class="sp-body">1. Самый простой способ - использование Турбо-режима (экономии трафика) в браузерах Chrome, Opera , <a href="https://play.google.com/store/apps/details?id=com.UCMobile.intl" class="postLink">UC Browser</a> и т.п. (включается в настройках). <span class="post-u">После перехода на https данный режим работать у нас не будет!</span>
+<div class="sp-wrap">
+<div class="sp-head folded"><span>Пример включения режима в Chrome</span></div>
+<div class="sp-body"><var class="postImg" title="http://rutracker.wiki/images/6/63/2step.png">&#10;</var></div>
+</div>
+2. Использование <a href="https://play.google.com/store/apps/details?id=info.guardianproject.orfox&amp;hl=ru" class="postLink">Orfox: Tor Browser for Android</a>
+<div class="sp-wrap">
+<div class="sp-head folded"><span>Настройка OrFox для Рутрекера</span></div>
+<div class="sp-body"><var class="postImg" title="http://i74.fastpic.ru/big/2016/0125/09/76382a529f4b490a55d2fe2ce391ce09.png">&#10;</var></div>
+</div>
+3. <a href="https://play.google.com/store/apps/details?id=com.cloudflare.onedotonedotonedotone" class="postLink">1.1.1.1: Faster &amp; Safer Internet</a><br>
+4. <a href="https://psiphon.ca/ru/download.html" class="postLink">Psiphon</a><br>
+5. <a href="https://play.google.com/store/apps/details?id=com.cloudmosa.puffinFree" class="postLink">Puffin Web Browser</a><br>
+6. <a href="https://www.tunnelbear.com/" class="postLink">Tunnelbear</a><br>
+7. <a href="http://antizapret.prostovpn.org/" class="postLink">Антизапрет</a><br>
+8. <a href="https://www.betternet.co/" class="postLink">Betternet</a><br>
+9. <a href="https://play.google.com/store/apps/details?id=org.torproject.android&amp;hl=en" class="postLink">Orbot</a> (гон трафика через Tor)<br>
+10. <a href="http://vpntrue.net/" class="postLink">Оф. сайт</a> | <a href="http://rghost.ru/6GGxMgG6G" class="postLink">Отличная версия: 0.0.2.0 от PAPAsha53</a>
+<div class="sp-wrap">
+<div class="sp-head folded"><span>Инструкция для VPN True</span></div>
+<div class="sp-body">(смотрим программу на 4 p d a.ru <img class="smile" src="https://static.rutracker.cc/smiles/icon_wink.gif" alt=""> )<br>
+Краткое описание:<br>
+<span class="post-b">Доступ к ресурсам Интернет через сеть бесплатных VPN-серверов.</span><span class="post-br"><br></span><span class="post-b">Описание</span>:<br>
+Программа имеет <span class="post-b">два режима халявного доступа:</span><br>
+а) <span class="post-b">вообще без регистрации</span> - сервер выбирается <span class="post-b">автоматически</span> случайным образом<br>
+б) <span class="post-b">с регистрацией(бесплатной)</span> - появляется <span class="post-b">возможность выбора б/м подходящего сервера из списка</span> (список серверов значительно пошире чем в "а")<span class="post-br"><br></span>управление программой - незамысловатое.<br>
+рекламы в программе не замечено<br>
+ограничений по скорости/трафику,времени вроде тоже.<br>
+во всяк случае пока<br>
+творение не без мелких глюков но вполне юзабельно<br>
+главное что сетка серверов не особо загружена<br>
+<span class="post-b">P.S.</span><br>
+творцы уверяют что халявные режимы изымать не будут,<br>
+будущее покажет но в любом случае пока что можно пользоваться<br>
+<span class="post-b">активно и бесплатно</span></div>
+</div>
+11. <a href="https://play.google.com/store/apps/details?id=de.mobileconcepts.cyberghost" class="postLink">Cyberghost</a>
+<div class="sp-wrap">
+<div class="sp-head folded"><span>Краткое описание</span></div>
+<div class="sp-body">У меня все устанавливалось, но с настройками толком ничего не понятно. И нужен доступ с мобильного планшета (у меня Самсунг галакси) не только к Рутрекеру и торрентам, но и к онлайн-просмотру видео на заблокированных сайтах.<span class="post-br"><br></span>В итоге я нашла то, что подошло лично мне и прекрасно работает, включая видео на Бигсинема и подобных сайтах. Кстати, настройки в приложении на русском языке. Делюсь, может, еще кому пригодится!</div>
+</div>
+12. <a href="http://lmgtfy.com/?q=Hotspot+Shield+VPN+4%D0%B7%D0%B2%D1%84" class="postLink">Hotspot Shield VPN</a> (первая ссылка в Гугле). Можно использовать в связке с UC Browser<br>
+13. <a href="https://play.google.com/store/apps/details?id=com.opera.max.global&amp;hl=ru" class="postLink">Opera Max</a> (Бесплатное приложение для экономии трафика. По сути - бесплатный VPN)<br>
+14. VpnGate List в связке с OpenVPN
+<div class="sp-wrap">
+<div class="sp-head folded"><span>Инструкция для п. 12</span></div>
+<div class="sp-body">1. Качаем приложение <a href="https://play.google.com/store/apps/details?id=net.rejinderi.vpngatelist&amp;hl=ru" class="postLink">OpenVPN</a><br>
+<var class="postImg" title="http://s018.radikal.ru/i523/1511/66/9f1a50e256d1.png">&#10;</var><br>
+2. Берем файл настроек из постоянно обновляющегося списка (бесплатных) VPN серверов из проекта <a href="http://www.vpngate.net/" class="postLink">VpnGate</a> . Для удобства можно скачать приложение <a href="https://play.google.com/store/apps/details?id=net.rejinderi.vpngatelist&amp;hl=ru" class="postLink">Vpngate</a><br>
+<var class="postImg" title="http://s017.radikal.ru/i423/1511/af/1562ed60efc4.png">&#10;</var><br>
+3. Выбираем сервер из списка Vpn Gate<br>
+<var class="postImg" title="http://i016.radikal.ru/1511/87/360fdaf22c66.png">&#10;</var><br>
+4. Экспортируем в Openvpn (открываем скачанный файл в приложении)<br>
+<var class="postImg" title="http://s011.radikal.ru/i316/1511/f5/96de83f787f0.png">&#10;</var><br>
+5. Подключаемся<br>
+<var class="postImg" title="http://s019.radikal.ru/i644/1511/6f/a002d6355252.png">&#10;</var></div>
+</div>
+15. То же самое, что и п. 12, только вместо VPN Gate List использовать <a href="http://lmgtfy.com/?q=EasyOvpn" class="postLink">EasyOvpn</a><br>
+16. <span class="post-b">VPN Ninja</span><br>
+17. <a href="https://www.shellfire.net/vpn/" class="postLink">ShellfireVPN</a><br>
+18. <a href="https://play.google.com/store/apps/details?id=org.hola&amp;hl=ru&amp;referrer=utm_source%3Dgoogle%26utm_medium%3Dorganic%26utm_term%3Dhola&amp;pcampaignid=APPU_1_1f1MVp2rJomBywO0r72YAg" class="postLink">Hola</a><br>
+19. <a href="https://www.finchvpn.com/download/" class="postLink">FinchVPN</a><br>
+20. <a href="https://play.google.com/store/apps/details?id=com.globus.vpn" class="postLink">VPN+TOR Globus Pro!</a> - Аномайзер без необходимости получения Root-прав. Просто включаем и пользуемся любимым браузером)<br>
+21. <span class="post-b">ZenMate</span> (но он стоит много денег)</div>
+</div>
+<div class="sp-wrap">
+<div class="sp-head folded"><span>iOS</span></div>
+<div class="sp-body">1. <a href="https://itunes.apple.com/ru/app/onion-browser/id519296448?mt=8" class="postLink">Onion Browser</a><br>
+2. <a href="https://itunes.apple.com/ru/app/browsec-vpn-internet-privacy/id978583103?mt=8" class="postLink">Browsec VPN</a> (бесплатный и простой, iOS 8 и выше)<br>
+3. <span class="post-b">Onion VPN with Tor</span> - Установив, далее разберетесь. Программа добавить свои профили VPN. И заходит быстро на все заблокированные сайты. Не надо никаких браузеров лишних. Вам остается лишь переводит тумблер вкл-выкл VPN. Тестил на iOS 6.1.3.<br>
+4. <a href="https://www.tunnelbear.com/" class="postLink">Tunnelbear</a><br>
+5. <a href="http://antizapret.prostovpn.org/" class="postLink">Антизапрет</a><br>
+6. <a href="https://www.betternet.co/" class="postLink">Betternet</a><br>
+7. <a href="viewtopic.php?t=5106122" class="postLink">Тор-браузер Red Onion для IOS (раздача)</a><br>
+8. Для Jailbreak-взломанных устройств - в Cydia ставим твик <span class="post-b">Tunnelbear Hack VPN</span><br>
+9. <a href="https://www.finchvpn.com/download/" class="postLink">FinchVPN</a> + OpenVPN<br>
+10. <a href="https://itunes.apple.com/ru/app/red-onion-tor-powered-web/id829739720?mt=8" class="postLink">Red Onion</a> (правда стоит 59 рублей)<br>
+11. <span class="post-b">ZenMate</span> (но он стоит много денег)</div>
+</div>
+<div class="sp-wrap">
+<div class="sp-head folded"><span>Windows Phone</span></div>
+<div class="sp-body">1. <span class="post-b">Простое быстрое Решение для Windows Phone 10</span> (должно работать и на 8-х WP, проверю на днях)
+<div class="sp-wrap">
+<div class="sp-head folded"><span>скрытый текст</span></div>
+<div class="sp-body">Изначально сайт закрытый отображается так:<br>
+<a href="https://fastpic.ru/view/66/2015/1126/f28fa212cf73ba512112ac6cf121d335.png.html" class="postLink"><var class="postImg" title="http://i66.fastpic.ru/thumb/2015/1126/35/f28fa212cf73ba512112ac6cf121d335.jpeg">&#10;</var></a><br>
+Идём в настройки сети:<br>
+<a href="https://fastpic.ru/view/67/2015/1126/028cb85261b5fd53d7e6fc4abb50e7fd.png.html" class="postLink"><var class="postImg" title="http://i67.fastpic.ru/thumb/2015/1126/fd/028cb85261b5fd53d7e6fc4abb50e7fd.jpeg">&#10;</var></a><br>
+Во вкладку VPN и там жмём добавить VPN<br>
+<a href="https://fastpic.ru/view/75/2015/1126/407481fecfbf0ce8ac6786a9ffb67e37.png.html" class="postLink"><var class="postImg" title="http://i75.fastpic.ru/thumb/2015/1126/37/407481fecfbf0ce8ac6786a9ffb67e37.jpeg">&#10;</var></a><br>
+Забиваем туда данные, используя поиск гугль, яндекс или любой другой. Я взял первый попавшийся сайт <a href="https://www.vpnme.me/ru/freevpn.html" class="postLink">https://www.vpnme.me/ru/freevpn.html</a> и вбил данные оттуда. И, сохранив настройки, нажимаем подключиться:<br>
+<a href="https://fastpic.ru/view/76/2015/1126/fcf86278ccffb6e2c00b08d436b89e52.png.html" class="postLink"><var class="postImg" title="http://i76.fastpic.ru/thumb/2015/1126/52/fcf86278ccffb6e2c00b08d436b89e52.jpeg">&#10;</var></a><br>
+И, О ЧУДО! It's alive!<br>
+<a href="https://fastpic.ru/view/76/2015/1126/112e001942cce05ad3c6d15e737f6a7d.png.html" class="postLink"><var class="postImg" title="http://i76.fastpic.ru/thumb/2015/1126/7d/112e001942cce05ad3c6d15e737f6a7d.jpeg">&#10;</var></a></div>
+</div>
+2. <span class="post-b">Opera Mini</span> - режим <span class="post-s">турбо</span> "экономия трафика" (быстрым режимом). Проверено на WinPhone 10.<br>
+3. <span class="post-b">UC Browser</span> - открывает заблокированные сайты без каких либо дополнительных действий<br>
+4. Через прокси
+<div class="sp-wrap">
+<div class="sp-head folded"><span>скрытый текст</span></div>
+<div class="sp-body">Сидя же из-под Вай-Фая - тыкаем на название активной сети - <span class="post-u">прокси-сервер</span> -&gt; <span class="post-s">Вкл.</span><br>
+Прокси сервера берем, например, <a href="http://fineproxy.org/здесь" class="postLink">http://fineproxy.org/здесь</a> .<br>
+Работает на любом браузере.</div>
+</div>
+5. <span class="post-b">VPN на Windows Phone</span>
+<div class="sp-wrap">
+<div class="sp-head folded"><span>скрытый текст</span></div>
+<div class="sp-body">1. Идем в настройки, создаем VPN подключение из списка <a href="http://www.vpngate.net" class="postLink">http://www.vpngate.net</a>. Важно, чтобы подключение поддерживало L2TP/IPsec. Включаем и пользуемся VPN. Понятно, что бесплатное подключение имеет ограничения по скорости или времени.<br>
+2. Идем в магазин и ставим бесплатное приложение, например, VPN IN TOUCH, покупаем время или трафик.</div>
+</div>
+6. <span class="post-b">wpTorrent</span> - Ищите в магазине среди бесплатных приложений. Раздел инструменты+работа</div>
+</div>
+<div class="sp-wrap">
+<div class="sp-head folded"><span>Symbian</span></div>
+<div class="sp-body">1. <a href="http://ru.ucweb.com/" class="postLink">UC Browser</a> - И экономия трафика и нормальный загрузчик, а не как у некоторых, темы, блокировка рекламы, сохранение страницы, свой видео плеер, файловый менеджер, погода и курс валют на первой странице.<br>
+2. <span class="post-b">Опера</span> - и мобайл, и мини.</div>
+</div>
+<div class="sp-wrap">
+<div class="sp-head folded"><span>Java</span></div>
+<div class="sp-body">Подойдет для очень старых Android'ов (с java-эмулятором на борту), Windows Mobile, Bada, эмулятора JAVA для PSP, а также Symbian<br>
+<span class="post-i">От себя</span><br>
+1. <span class="post-b">UC Browser</span> - <a href="http://waploft.com/fileDownload/48033/UCBrowser_V9.5.0.449_Java_UC_Browser.html" class="postLink">Ссылка на точно рабочую версию</a>
+<div class="sp-wrap">
+<div class="sp-head folded"><span>скрытый текст</span></div>
+<div class="sp-body">UCBrowser V9.5.0.449 Java UC Browser.jar 457.74 kb</div>
+</div>
+<a href="http://www.ucweb.com/ucbrowser/download/java.html" class="postLink">Оф. сайт</a>. Работает сразу же, на крайняк можно настройках Network'а можно настроить прокси. Скриншот:<br>
+<a href="http://radikal.ru/fp/f2b6b1f842ab49d8adb17fc6a358b717" class="postLink"><var class="postImg" title="http://s019.radikal.ru/i634/1601/21/158c2b693a5at.jpg">&#10;</var></a><br>
+2. <span class="post-b">Opera Mini</span> - <a href="https://trashbox.ru/link/opera-mini-7-java" class="postLink">Ссылка на точно рабочую версию</a>.
+<div class="sp-wrap">
+<div class="sp-head folded"><span>скрытый текст</span></div>
+<div class="sp-body">Opera Mini 8.0.35626 (jar) 312,9 КБ Добавил: Kamel-87</div>
+</div>
+Есть русский язык, QWERTY-клавиатура. Скриншот:<br>
+<a href="http://radikal.ru/fp/884d4befa80b4dfc9c85de953a2ab7f1" class="postLink"><var class="postImg" title="http://s020.radikal.ru/i701/1601/a0/22b380c4ab0ft.jpg">&#10;</var></a></div>
+</div>
+</div>
+</div>
+<hr class="post-hr"><hr class="post-hr">Если перечисленные способы не помогают - попробуйте зайти через одно из зеркал рутрекера (rutracker.net или rutracker.cr)<br>
+Если есть проблемы со скачиванием торрент-файла - используйте магнет-ссылку.<hr class="post-hr">
+<div class="q-wrap">
+<div class="q-head"><span><b>empty_sys</b> писал(а):</span></div>
+<div class="q"><u class="q-post">70167009</u>Сейчас уже недели две успешно юзаю рутрекер через скачанный с Play Market бесплатный Fire.onion (Browser + Tor), никаких проблем с ним нет.</div>
+</div>
+<a href="https://play.google.com/store/apps/details?id=onion.fire&amp;hl=ru" class="postLink">https://play.google.com/store/apps/details?id=onion.fire&amp;hl=ru</a><hr class="post-hr"><hr class="post-hr"><hr class="post-hr"><hr class="post-hr"><hr class="post-hr"><hr class="post-hr">
+<div class="q-wrap">
+<div class="q-head"><span><b>Papant</b> писал(а):</span></div>
+<div class="q"><u class="q-post">77457361</u>Теперь наш плагин для Мозиллы работает и на андроиде.<br>
+<a href="https://addons.mozilla.org/firefox/addon/rutracker-add-on/" class="postLink">https://addons.mozilla.org/firefox/addon/rutracker-add-on/</a></div>
+</div>											</div><!--/post_body-->
+
+			
+			<div class="clear" style="height: 8px;"></div>
+
+			
+			
+			<div class="clear"></div>
+			<div class="spacer_6"></div>
+
+			
+			
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=227805">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=227805">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_69257306" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="69257306"></a>
+		
+		
+				<p class="nick ">saidrostov</p>
+		
+		
+								<p class="joined"><em>Стаж:</em> 15 лет 7 месяцев</p>		<p class="posts"><em>Сообщений:</em> 7</p>		
+		
+		<br>	</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">saidrostov &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=69257306#69257306">14-Ноя-15 00:38</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 24 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=69257306">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-2">
+						<div class="post_body" id="p-69257306" data-ext_link_data='{"p":69257306,"t":5116006,"f":659,"u":20124302}'>
+													Бесплатное приложение Betternet, включает VPN на смартфоне и пользуешься любым удобным браузером! Думаю и аналоги есть, лень искать. А что, кто-то знает про торренты и не знает как блокировки обойти?											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=20124302">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=20124302">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_69257326" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="69257326"></a>
+		
+		
+				<p class="nick ">monreal77</p>
+		
+		
+				<p class="rank_img"><img class="user-rank" src="https://static.rutracker.cc/ranks/s_topbonus_4.gif" alt="Top Bonus 04* 3TB"></p>		<p class="avatar"><img src="https://static.rutracker.cc/avatars/4/20/24055020.jpg" alt=""></p>		<p class="joined"><em>Стаж:</em> 14 лет 7 месяцев</p>		<p class="posts"><em>Сообщений:</em> 495</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">monreal77 &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=69257326#69257326">14-Ноя-15 00:40</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 2 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=69257326">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-3">
+						<div class="post_body" id="p-69257326" data-ext_link_data='{"p":69257326,"t":5116006,"f":659,"u":24055020}'>
+													У Хрома отображение страниц очень корявое, шрифты гуляют.<br>
+С ним только на мобильных версиях сайтов сидеть.<br>
+Зачем его в шапку на первое место..<br>
+У всяких Иандекс-браусеров и новой Оперы, впрочем, тоже самое.											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=24055020">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=24055020">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_69257783" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="69257783"></a>
+		
+		
+				<p class="nick ">Ronin427</p>
+		
+		
+				<p class="rank_img"><img class="user-rank" src="https://static.rutracker.cc/ranks/s_topbonus_3.gif" alt="Top Bonus 03* 1TB"></p>		<p class="avatar"><img src="https://static.rutracker.cc/avatars/3/65/15228765.png" alt=""></p>		<p class="joined"><em>Стаж:</em> 16 лет 4 месяца</p>		<p class="posts"><em>Сообщений:</em> 11050</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">Ronin427 &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=69257783#69257783">14-Ноя-15 02:15</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 1 час 34 мин., ред. 14-Ноя-15 02:15)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=69257783">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-4">
+						<div class="post_body" id="p-69257783" data-ext_link_data='{"p":69257783,"t":5116006,"f":659,"u":15228765}'>
+													<span class="post-b">UC Browser</span> для Андроид, так же позволяет ходить куда хочешь, сжатие включено по дефолту. И он намного легче Хрома. <img class="smile" src="https://static.rutracker.cc/smiles/icon_smile.gif" alt=""><br>
+<a href="https://play.google.com/store/apps/details?id=com.UCMobile.intl" class="postLink">https://play.google.com/store/apps/details?id=com.UCMobile.intl</a>											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=15228765">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=15228765">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_69258259" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="69258259"></a>
+		
+		
+				<p class="nick ">.Kotori.</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/0/23/4973123.gif" alt=""></p>		<p class="joined"><em>Стаж:</em> 17 лет 9 месяцев</p>		<p class="posts"><em>Сообщений:</em> 53</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">.Kotori. &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=69258259#69258259">14-Ноя-15 03:57</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 1 час 41 мин., ред. 14-Ноя-15 03:57)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=69258259">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-5">
+						<div class="post_body" id="p-69258259" data-ext_link_data='{"p":69258259,"t":5116006,"f":659,"u":4973123}'>
+													Так же на андроиде можно использовать Orbot (в Google Play так и называется), который может гонять трафик любого приложения через Tor.<br>
+лично я им давно уже пользуюсь для того чтобы юзать OPDS-каталог флибусты, которая тоже уже несколько месяцев как заблокирована в Росиии.											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=4973123">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=4973123">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_69258977" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="69258977"></a>
+		
+		
+				<p class="nick ">bm_s</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/0/0/3435000.gif" alt=""></p>		<p class="joined"><em>Стаж:</em> 18 лет 1 месяц</p>		<p class="posts"><em>Сообщений:</em> 485</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">bm_s &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=69258977#69258977">14-Ноя-15 09:39</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 5 часов, ред. 14-Ноя-15 19:30)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=69258977">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-6">
+						<div class="post_body" id="p-69258977" data-ext_link_data='{"p":69258977,"t":5116006,"f":659,"u":3435000}'>
+													<img class="smile" src="https://static.rutracker.cc/smiles/icon_smile.gif" alt="">											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=3435000">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=3435000">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_69259044" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="69259044"></a>
+		
+		
+				<p class="nick ">zloyKrogan</p>
+		
+		
+								<p class="joined"><em>Стаж:</em> 12 лет 2 месяца</p>		<p class="posts"><em>Сообщений:</em> 8</p>		
+		
+		<br>	</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">zloyKrogan &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=69259044#69259044">14-Ноя-15 09:41</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 1 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=69259044">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-7">
+						<div class="post_body" id="p-69259044" data-ext_link_data='{"p":69259044,"t":5116006,"f":659,"u":35496141}'>
+													<div class="q-wrap">
+<div class="q-head"><span><b>monreal77</b> писал(а):</span></div>
+<div class="q"><u class="q-post">69257326</u>У Хрома отображение страниц очень корявое, шрифты гуляют.<br>
+С ним только на мобильных версиях сайтов сидеть.<br>
+Зачем его в шапку на первое место..<br>
+У всяких Иандекс-браусеров и новой Оперы, впрочем, тоже самое.</div>
+</div>
+Нормально все в Хроме. Всегда с него в инете сижу и сейчас тоже с него пишу. Ничего не тормозит, не виснет, вылетел всего пару раз за 1,5 года.<br>
+В настройках масштабирования текста надо поставить 100% и убрать галку Принудительное масштабирование. Единственный минус: при масштабировании страницы нет подстроения текста под размер экрана, как это было в Опера Мобайл(не знаю может и сейчас есть, не пользуюсь Оперой уже). И приходится влево-вправо таскать страницу чтобы прочитать. Зато есть очень удобное масштабирование одним пальцем.											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=35496141">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=35496141">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_69259119" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="69259119"></a>
+		
+		
+				<p class="nick ">monreal77</p>
+		
+		
+				<p class="rank_img"><img class="user-rank" src="https://static.rutracker.cc/ranks/s_topbonus_4.gif" alt="Top Bonus 04* 3TB"></p>		<p class="avatar"><img src="https://static.rutracker.cc/avatars/4/20/24055020.jpg" alt=""></p>		<p class="joined"><em>Стаж:</em> 14 лет 7 месяцев</p>		<p class="posts"><em>Сообщений:</em> 495</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">monreal77 &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=69259119#69259119">14-Ноя-15 09:55</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 14 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=69259119">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-8">
+						<div class="post_body" id="p-69259119" data-ext_link_data='{"p":69259119,"t":5116006,"f":659,"u":24055020}'>
+													<div class="q-wrap">
+<div class="q-head"><span><b>zloyKrogan</b> писал(а):</span></div>
+<div class="q">Единственный минус: при масштабировании страницы нет подстроения текста под размер экрана, как это было в Опера Мобайл(не знаю может и сейчас есть, не пользуюсь Оперой уже). И приходится влево-вправо таскать страницу чтобы прочитать.</div>
+</div>
+Это перечёркивает все плюсы. Поэтому до сих пор пользуюсь старой Оперой.											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=24055020">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=24055020">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_69259172" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="69259172"></a>
+		
+		
+				<p class="nick ">08dk</p>
+		
+		
+								<p class="joined"><em>Стаж:</em> 11 лет 7 месяцев</p>		<p class="posts"><em>Сообщений:</em> 3</p>		
+		
+		<br>	</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">08dk &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=69259172#69259172">14-Ноя-15 10:05</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 9 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=69259172">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-9">
+						<div class="post_body" id="p-69259172" data-ext_link_data='{"p":69259172,"t":5116006,"f":659,"u":37318751}'>
+													А для динозавров на симбиане есть что?											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=37318751">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=37318751">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_69259664" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="69259664"></a>
+		
+		
+				<p class="nick ">zloyKrogan</p>
+		
+		
+								<p class="joined"><em>Стаж:</em> 12 лет 2 месяца</p>		<p class="posts"><em>Сообщений:</em> 8</p>		
+		
+		<br>	</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">zloyKrogan &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=69259664#69259664">14-Ноя-15 11:24</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 1 час 19 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=69259664">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-10">
+						<div class="post_body" id="p-69259664" data-ext_link_data='{"p":69259664,"t":5116006,"f":659,"u":35496141}'>
+													<span class="post-b">monreal77</span><br>
+Ну в принципе, можно так отмасштабировать чтобы текст влазил полностью, без переноса. Мелковато правда, но читаемо на 5" экране. Хотя согласен, неудобства доставляет. Не понимаю почему Гугль ничего с этим не сделает.<br>
+Можно еще экран перевести в горозонталку, тогда нормально все влазит и размер текста нормальный.											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=35496141">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=35496141">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_69260175" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="69260175"></a>
+		
+		
+				<p class="nick ">bm_s</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/0/0/3435000.gif" alt=""></p>		<p class="joined"><em>Стаж:</em> 18 лет 1 месяц</p>		<p class="posts"><em>Сообщений:</em> 485</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">bm_s &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=69260175#69260175">14-Ноя-15 12:40</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 1 час 15 мин., ред. 14-Ноя-15 12:40)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=69260175">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-11">
+						<div class="post_body" id="p-69260175" data-ext_link_data='{"p":69260175,"t":5116006,"f":659,"u":3435000}'>
+													<div class="q-wrap">
+<div class="q-head"><span><b>monreal77</b> писал(а):</span></div>
+<div class="q">Поэтому до сих пор пользуюсь старой Оперой.</div>
+</div>
+А я новым Boat Browser for Tablet. Идеальная подгонка текста под экран, без хромовского кореженья шрифтов. Сравниваем: лодка <a href="http://clip2net.com/s/3qj2zXq" class="postLink">http://clip2net.com/s/3qj2zXq</a> и хром <a href="http://clip2net.com/s/3qj2LgB" class="postLink">http://clip2net.com/s/3qj2LgB</a>											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=3435000">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=3435000">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_69260230" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="69260230"></a>
+		
+		
+				<p class="nick ">doc_ravik</p>
+		
+		
+				<p class="rank_img"><img class="user-rank" src="https://static.rutracker.cc/ranks/s_support_gray.gif" alt="Техническая помощь (неактивен)"></p>		<p class="avatar"><img src="https://static.rutracker.cc/avatars/3/70/18553470.gif" alt=""></p>		<p class="joined"><em>Стаж:</em> 15 лет 10 месяцев</p>		<p class="posts"><em>Сообщений:</em> 12487</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">doc_ravik &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=69260230#69260230">14-Ноя-15 12:41</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 1 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=69260230">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-12">
+						<div class="post_body" id="p-69260230" data-ext_link_data='{"p":69260230,"t":5116006,"f":659,"u":18553470}'>
+													<div class="q-wrap">
+<div class="q-head"><span><b>bm_s</b> писал(а):</span></div>
+<div class="q"><u class="q-post">69260175</u>Boat Browser</div>
+</div>
+Как там с анонимностью?											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=18553470">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=18553470">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_69260252" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="69260252"></a>
+		
+		
+				<p class="nick ">bm_s</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/0/0/3435000.gif" alt=""></p>		<p class="joined"><em>Стаж:</em> 18 лет 1 месяц</p>		<p class="posts"><em>Сообщений:</em> 485</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">bm_s &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=69260252#69260252">14-Ноя-15 12:44</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 2 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=69260252">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-13">
+						<div class="post_body" id="p-69260252" data-ext_link_data='{"p":69260252,"t":5116006,"f":659,"u":3435000}'>
+													<div class="q-wrap">
+<div class="q-head"><span><b>doc_ravik</b> писал(а):</span></div>
+<div class="q"><u class="q-post">69260230</u>
+<div class="q-wrap">
+<div class="q-head"><span><b>bm_s</b> писал(а):</span></div>
+<div class="q"><u class="q-post">69260175</u>Boat Browser</div>
+</div>
+Как там с анонимностью?</div>
+</div>
+как проверить?											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=3435000">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=3435000">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_69260256" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="69260256"></a>
+		
+		
+				<p class="nick ">doc_ravik</p>
+		
+		
+				<p class="rank_img"><img class="user-rank" src="https://static.rutracker.cc/ranks/s_support_gray.gif" alt="Техническая помощь (неактивен)"></p>		<p class="avatar"><img src="https://static.rutracker.cc/avatars/3/70/18553470.gif" alt=""></p>		<p class="joined"><em>Стаж:</em> 15 лет 10 месяцев</p>		<p class="posts"><em>Сообщений:</em> 12487</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">doc_ravik &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=69260256#69260256">14-Ноя-15 12:45</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 1 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=69260256">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-14">
+						<div class="post_body" id="p-69260256" data-ext_link_data='{"p":69260256,"t":5116006,"f":659,"u":18553470}'>
+													<span class="post-b">bm_s</span><br>
+Что-нибудь про сжатие данных есть в настройках?											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=18553470">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=18553470">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_69260292" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="69260292"></a>
+		
+		
+				<p class="nick ">bm_s</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/0/0/3435000.gif" alt=""></p>		<p class="joined"><em>Стаж:</em> 18 лет 1 месяц</p>		<p class="posts"><em>Сообщений:</em> 485</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">bm_s &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=69260292#69260292">14-Ноя-15 12:50</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 4 мин., ред. 14-Ноя-15 13:01)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=69260292">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-15">
+						<div class="post_body" id="p-69260292" data-ext_link_data='{"p":69260292,"t":5116006,"f":659,"u":3435000}'>
+													<span class="post-b">doc_ravik</span>, нету											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=3435000">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=3435000">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_69260305" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="69260305"></a>
+		
+		
+				<p class="nick ">doc_ravik</p>
+		
+		
+				<p class="rank_img"><img class="user-rank" src="https://static.rutracker.cc/ranks/s_support_gray.gif" alt="Техническая помощь (неактивен)"></p>		<p class="avatar"><img src="https://static.rutracker.cc/avatars/3/70/18553470.gif" alt=""></p>		<p class="joined"><em>Стаж:</em> 15 лет 10 месяцев</p>		<p class="posts"><em>Сообщений:</em> 12487</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">doc_ravik &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=69260305#69260305">14-Ноя-15 12:52</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 1 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=69260305">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-16">
+						<div class="post_body" id="p-69260305" data-ext_link_data='{"p":69260305,"t":5116006,"f":659,"u":18553470}'>
+													<span class="post-b">bm_s</span><br>
+Да, я уже посмотрел.											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=18553470">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=18553470">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_69260364" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="69260364"></a>
+		
+		
+				<p class="nick ">doc_ravik</p>
+		
+		
+				<p class="rank_img"><img class="user-rank" src="https://static.rutracker.cc/ranks/s_support_gray.gif" alt="Техническая помощь (неактивен)"></p>		<p class="avatar"><img src="https://static.rutracker.cc/avatars/3/70/18553470.gif" alt=""></p>		<p class="joined"><em>Стаж:</em> 15 лет 10 месяцев</p>		<p class="posts"><em>Сообщений:</em> 12487</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">doc_ravik &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=69260364#69260364">14-Ноя-15 13:01</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 9 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=69260364">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-17">
+						<div class="post_body" id="p-69260364" data-ext_link_data='{"p":69260364,"t":5116006,"f":659,"u":18553470}'>
+													Кто-нибудь пробовал <a href="https://play.google.com/store/apps/details?id=de.mobileconcepts.cyberghost" class="postLink">https://play.google.com/store/apps/details?id=de.mobileconcepts.cyberghost</a> ?											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=18553470">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=18553470">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_69260388" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="69260388"></a>
+		
+		
+				<p class="nick ">bm_s</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/0/0/3435000.gif" alt=""></p>		<p class="joined"><em>Стаж:</em> 18 лет 1 месяц</p>		<p class="posts"><em>Сообщений:</em> 485</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">bm_s &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=69260388#69260388">14-Ноя-15 13:06</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 4 мин., ред. 14-Ноя-15 19:53)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=69260388">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-18">
+						<div class="post_body" id="p-69260388" data-ext_link_data='{"p":69260388,"t":5116006,"f":659,"u":3435000}'>
+													<div class="q-wrap">
+<div class="q-head"><span><b>doc_ravik</b> писал(а):</span></div>
+<div class="q"><u class="q-post">69260364</u>Кто-нибудь пробовал <a href="https://play.google.com/store/apps/details?id=de.mobileconcepts.cyberghost" class="postLink">https://play.google.com/store/apps/details?id=de.mobileconcepts.cyberghost</a> ?</div>
+</div>
+Установил - подключилось, сказали, что работаю из Румынии. Рутрекер в браузерах грузится, но актуальная для меня прога Трекер ассистент <a href="https://play.google.com/store/apps/details?id=com.formalizationunit.trackerassistant.ext" class="postLink">https://play.google.com/store/apps/details?id=com.formalizationunit.trackerassistant.ext</a> доступа к ресурсу не получает.<br>
+А вот Hotspot Shield VPN для Android порадовала, (на 4pda есть полная версия), вот только скорость невысока.											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=3435000">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=3435000">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_69260411" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="69260411"></a>
+		
+		
+				<p class="nick ">monreal77</p>
+		
+		
+				<p class="rank_img"><img class="user-rank" src="https://static.rutracker.cc/ranks/s_topbonus_4.gif" alt="Top Bonus 04* 3TB"></p>		<p class="avatar"><img src="https://static.rutracker.cc/avatars/4/20/24055020.jpg" alt=""></p>		<p class="joined"><em>Стаж:</em> 14 лет 7 месяцев</p>		<p class="posts"><em>Сообщений:</em> 495</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">monreal77 &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=69260411#69260411">14-Ноя-15 13:09</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 3 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=69260411">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-19">
+						<div class="post_body" id="p-69260411" data-ext_link_data='{"p":69260411,"t":5116006,"f":659,"u":24055020}'>
+													<div class="q-wrap">
+<div class="q-head"><span><b>bm_s</b> писал(а):</span></div>
+<div class="q"><u class="q-post">69260175</u>
+<div class="q-wrap">
+<div class="q-head"><span><b>monreal77</b> писал(а):</span></div>
+<div class="q">Поэтому до сих пор пользуюсь старой Оперой.</div>
+</div>
+А я новым Boat Browser for Tablet. Идеальная подгонка текста под экран, без хромовского кореженья шрифтов. Сравниваем: лодка <a href="http://clip2net.com/s/3qj2zXq" class="postLink">http://clip2net.com/s/3qj2zXq</a> и хром <a href="http://clip2net.com/s/3qj2LgB" class="postLink">http://clip2net.com/s/3qj2LgB</a></div>
+</div>
+Тема не совсем о этом, но всё же.<br>
+Пользовался я Boat, а также тестил несколько десятков других браузеров. Если ставить более-менее крупный шрифт, то проблемы с отображением страниц всё равно появляются на некоторых сайтах.<br>
+Исключения - старая Opera Mobile, которую уже убрали из Маркета и HTC-браузер (OEM), который добрые люди выдернули из прошивки (похож на стандартный браузер Гугла, но лучше.											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=24055020">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=24055020">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_69260442" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="69260442"></a>
+		
+		
+				<p class="nick ">doc_ravik</p>
+		
+		
+				<p class="rank_img"><img class="user-rank" src="https://static.rutracker.cc/ranks/s_support_gray.gif" alt="Техническая помощь (неактивен)"></p>		<p class="avatar"><img src="https://static.rutracker.cc/avatars/3/70/18553470.gif" alt=""></p>		<p class="joined"><em>Стаж:</em> 15 лет 10 месяцев</p>		<p class="posts"><em>Сообщений:</em> 12487</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">doc_ravik &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=69260442#69260442">14-Ноя-15 13:13</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 4 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=69260442">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-20">
+						<div class="post_body" id="p-69260442" data-ext_link_data='{"p":69260442,"t":5116006,"f":659,"u":18553470}'>
+													Не оффтопим, пожалуйста.											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=18553470">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=18553470">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_69260458" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="69260458"></a>
+		
+		
+				<p class="nick ">monreal77</p>
+		
+		
+				<p class="rank_img"><img class="user-rank" src="https://static.rutracker.cc/ranks/s_topbonus_4.gif" alt="Top Bonus 04* 3TB"></p>		<p class="avatar"><img src="https://static.rutracker.cc/avatars/4/20/24055020.jpg" alt=""></p>		<p class="joined"><em>Стаж:</em> 14 лет 7 месяцев</p>		<p class="posts"><em>Сообщений:</em> 495</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">monreal77 &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=69260458#69260458">14-Ноя-15 13:15</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 2 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=69260458">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-21">
+						<div class="post_body" id="p-69260458" data-ext_link_data='{"p":69260458,"t":5116006,"f":659,"u":24055020}'>
+													Если не принципиальна страна IP, то на Android достаточно в Маркете в поисковой строке забить 'vpn' и выбрать любой из нескольких десятков VPN-клиентов.											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=24055020">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=24055020">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_69261853" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="69261853"></a>
+		
+		
+				<p class="nick ">sabire</p>
+		
+		
+				<p class="rank_img"><img class="user-rank" src="https://static.rutracker.cc/ranks/oldbie_2.gif" alt="Старожил"></p>				<p class="joined"><em>Стаж:</em> 16 лет 3 месяца</p>		<p class="posts"><em>Сообщений:</em> 100</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">sabire &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=69261853#69261853">14-Ноя-15 16:13</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 2 часа 58 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=69261853">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-22">
+						<div class="post_body" id="p-69261853" data-ext_link_data='{"p":69261853,"t":5116006,"f":659,"u":15757626}'>
+													Мобильный браузер Puffin.Пользуюсь бесплатной версией на айфоне и на андроиде. Открывает grani.ru и livetv.sx, к примеру.											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=15757626">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=15757626">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_69262487" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="69262487"></a>
+		
+				<p class="nick">Гость</p>
+		
+		<br>	</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">Гость &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=69262487#69262487">14-Ноя-15 17:41</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 1 час 27 мин., ред. 05-Июл-17 10:18)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=69262487">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-23">
+						<div class="post_body" id="p-69262487" data-ext_link_data='{"p":69262487,"t":5116006,"f":659,"u":1}'>
+													del											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				&nbsp;
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_69262670" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="69262670"></a>
+		
+		
+				<p class="nick ">Umuetat</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/6/53/33976353.png" alt=""></p>		<p class="joined"><em>Стаж:</em> 12 лет 6 месяцев</p>		<p class="posts"><em>Сообщений:</em> 124</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">Umuetat &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=69262670#69262670">14-Ноя-15 17:54</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 12 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=69262670">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-24">
+						<div class="post_body" id="p-69262670" data-ext_link_data='{"p":69262670,"t":5116006,"f":659,"u":33976353}'>
+													<span class="post-b"><span style="font-size: 14px; line-height: normal;">Тор-браузер Red Onion для IOS</span></span><br>
+<a href="viewtopic.php?t=5106122" class="postLink">https://rutracker.org/forum/viewtopic.php?t=5106122</a>											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=33976353">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=33976353">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_69269320" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="69269320"></a>
+		
+		
+				<p class="nick ">Undo81</p>
+		
+		
+								<p class="joined"><em>Стаж:</em> 18 лет 1 месяц</p>		<p class="posts"><em>Сообщений:</em> 17</p>		
+		
+		<br>	</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">Undo81 &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=69269320#69269320">15-Ноя-15 11:45</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 17 часов)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=69269320">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-25">
+						<div class="post_body" id="p-69269320" data-ext_link_data='{"p":69269320,"t":5116006,"f":659,"u":3462365}'>
+													<div class="sp-wrap">
+<div class="sp-head folded"><span>скрытый текст</span></div>
+<div class="sp-body"><span class="post-b">Android</span><span class="post-br"><br></span>1.<span class="post-b">Opera Max</span><br>
+<a href="https://play.google.com/store/apps/details?id=com.opera.max.global&amp;hl=ru" class="postLink"><var class="postImg" title="http://s010.radikal.ru/i312/1511/9b/82a38c7db6d1.png">&#10;</var></a><br>
+приложение для экономии трафика (по сути - бесплатный VPN)<br>
+<a href="https://play.google.com/store/apps/details?id=com.opera.max.global&amp;hl=ru" class="postLink">https://play.google.com/store/apps/details?id=com.opera.max.global&amp;hl=ru</a><span class="post-br"><br></span>2.<span class="post-b">vpn gate list</span> + <span class="post-b">openvpn connect</span><br>
+<a href="https://play.google.com/store/apps/details?id=net.rejinderi.vpngatelist&amp;hl=ru" class="postLink"><var class="postImg" title="http://s017.radikal.ru/i423/1511/af/1562ed60efc4.png">&#10;</var></a><br>
+обновляемый список (бесплатных) VPN серверов из проекта <a href="http://www.vpngate.net/" class="postLink">http://www.vpngate.net/</a><br>
+<a href="https://play.google.com/store/apps/details?id=net.rejinderi.vpngatelist&amp;hl=ru" class="postLink">https://play.google.com/store/apps/details?id=net.rejinderi.vpngatelist&amp;hl=ru</a><span class="post-br"><br></span><a href="https://play.google.com/store/apps/details?id=net.openvpn.openvpn&amp;hl=ru" class="postLink"><var class="postImg" title="http://s018.radikal.ru/i523/1511/66/9f1a50e256d1.png">&#10;</var></a><br>
+официальный OpenVPN-клиент для мобильных устройств на базе Android, разработанный компанией OpenVPN Technologies<br>
+<a href="https://play.google.com/store/apps/details?id=net.rejinderi.vpngatelist&amp;hl=ru" class="postLink">https://play.google.com/store/apps/details?id=net.rejinderi.vpngatelist&amp;hl=ru</a><span class="post-br"><br></span><var class="postImg" title="http://i016.radikal.ru/1511/87/360fdaf22c66.png">&#10;</var> <var class="postImg" title="http://s011.radikal.ru/i316/1511/f5/96de83f787f0.png">&#10;</var> <var class="postImg" title="http://s019.radikal.ru/i644/1511/6f/a002d6355252.png">&#10;</var><br>
+выбираем сервер из списка в <span class="post-b">vpn gate list</span>, экспортируем в <span class="post-b">openvpn connect</span>, подключаемся</div>
+</div>											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=3462365">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=3462365">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_69270149" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="69270149"></a>
+		
+		
+				<p class="nick ">monreal77</p>
+		
+		
+				<p class="rank_img"><img class="user-rank" src="https://static.rutracker.cc/ranks/s_topbonus_4.gif" alt="Top Bonus 04* 3TB"></p>		<p class="avatar"><img src="https://static.rutracker.cc/avatars/4/20/24055020.jpg" alt=""></p>		<p class="joined"><em>Стаж:</em> 14 лет 7 месяцев</p>		<p class="posts"><em>Сообщений:</em> 495</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">monreal77 &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=69270149#69270149">15-Ноя-15 13:13</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 1 час 27 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=69270149">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-26">
+						<div class="post_body" id="p-69270149" data-ext_link_data='{"p":69270149,"t":5116006,"f":659,"u":24055020}'>
+													<span class="post-b">Undo81</span><br>
+Вместо VPN Gate List лучше использовать EasyOvpn. Она удобнее.											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=24055020">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=24055020">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_69270444" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="69270444"></a>
+		
+		
+				<p class="nick ">Gefestel</p>
+		
+		
+				<p class="rank_img"><img class="user-rank" src="https://static.rutracker.cc/ranks/s_topseed_5.gif" alt="Top Seed 05* 640r"></p>		<p class="avatar"><img src="https://static.rutracker.cc/avatars/4/7/22098407.gif" alt=""></p>		<p class="joined"><em>Стаж:</em> 15 лет 1 месяц</p>		<p class="posts"><em>Сообщений:</em> 2797</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">Gefestel &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=69270444#69270444">15-Ноя-15 13:40</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 27 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=69270444">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-27">
+						<div class="post_body" id="p-69270444" data-ext_link_data='{"p":69270444,"t":5116006,"f":659,"u":22098407}'>
+													<div class="q-wrap">
+<div class="q-head"><span><b>08dk</b> писал(а):</span></div>
+<div class="q"><u class="q-post">69259172</u>А для динозавров на симбиане есть что?</div>
+</div>
+Тот-же <span class="post-b">UC Browser</span> на симбе позволяет юзать запретные сайты.											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=22098407">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=22098407">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_69281637" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="69281637"></a>
+		
+		
+				<p class="nick ">fozzy412</p>
+		
+		
+				<p class="rank_img"><img class="user-rank" src="https://static.rutracker.cc/ranks/s_topseed_1.gif" alt="Top Seed 01* 40r"></p>		<p class="avatar"><img src="https://static.rutracker.cc/avatars/1/80/9706180.jpg" alt=""></p>		<p class="joined"><em>Стаж:</em> 17 лет 2 месяца</p>		<p class="posts"><em>Сообщений:</em> 3227</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">fozzy412 &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=69281637#69281637">16-Ноя-15 17:19</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 1 день 3 часа)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=69281637">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-28">
+						<div class="post_body" id="p-69281637" data-ext_link_data='{"p":69281637,"t":5116006,"f":659,"u":9706180}'>
+													Юзал на андроида VPN Ninja - норм											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=9706180">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=9706180">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_69290323" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="69290323"></a>
+		
+		
+				<p class="nick ">Eaftefun</p>
+		
+		
+								<p class="joined"><em>Стаж:</em> 13 лет 4 месяца</p>		<p class="posts"><em>Сообщений:</em> 2</p>		
+		
+		<br>	</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">Eaftefun &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=69290323#69290323">17-Ноя-15 19:05</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 1 день 1 час)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=69290323">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-29">
+						<div class="post_body" id="p-69290323" data-ext_link_data='{"p":69290323,"t":5116006,"f":659,"u":30734643}'>
+													А Opera Max будет помогать? Включил, пользуешься чем хочешь, если да, было бы круто.											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=30734643">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=30734643">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_69290839" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="69290839"></a>
+		
+		
+				<p class="nick ">doc_ravik</p>
+		
+		
+				<p class="rank_img"><img class="user-rank" src="https://static.rutracker.cc/ranks/s_support_gray.gif" alt="Техническая помощь (неактивен)"></p>		<p class="avatar"><img src="https://static.rutracker.cc/avatars/3/70/18553470.gif" alt=""></p>		<p class="joined"><em>Стаж:</em> 15 лет 10 месяцев</p>		<p class="posts"><em>Сообщений:</em> 12487</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">doc_ravik &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=69290839#69290839">17-Ноя-15 20:08</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 1 час 3 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=69290839">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-30">
+						<div class="post_body" id="p-69290839" data-ext_link_data='{"p":69290839,"t":5116006,"f":659,"u":18553470}'>
+													<span class="post-b">Eaftefun</span><br>
+Ну пробуйте.											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=18553470">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=18553470">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+</table><!--/topic_main-->
+
+<script>$('img.smile').remove();</script>
+
+<table id="pagination" class="topic">
+<tr>
+	<td class="nav pad_6 row1">
+		<p style="float: left">Страница <b>1</b> из <b>21</b></p>
+		<p style="float: right" class="hide-for-print"><span class="pg-jump-menu"><a class="menu-root" href="#pg-jump" onclick="BB.focus_pg_input();">Страницы</a> :&nbsp;&nbsp;</span><b>1</b>, <a class="pg" href="viewtopic.php?t=5116006&amp;start=30">2</a>, <a class="pg" href="viewtopic.php?t=5116006&amp;start=60">3</a> ... <a class="pg" href="viewtopic.php?t=5116006&amp;start=540">19</a>, <a class="pg" href="viewtopic.php?t=5116006&amp;start=570">20</a>, <a class="pg" href="viewtopic.php?t=5116006&amp;start=600">21</a>&nbsp;&nbsp;<a class="pg" href="viewtopic.php?t=5116006&amp;start=30">След.</a></p>
+	</td>
+</tr>
+</table><!--/pagination-->
+
+
+<table class="topic hide-for-print">
+<tr>
+	<td class="catBottom med">
+		&nbsp;
+	</td>
+</tr>
+</table>
+
+<table class="w100 hide-for-print" style="padding-top: 2px;">
+<tr>
+	<td class="vTop">
+		<a href="posting.php?mode=reply&amp;t=5116006"><img src="https://static.rutracker.cc/templates/v1/images/reply.gif" alt="Ответить"></a>
+	</td>
+	<td class="nav w100" style="padding-left: 8px;">
+		<a href="index.php">Главная</a>
+		<em>&raquo;</em> <a href="index.php?c=36">ОБХОД БЛОКИРОВОК</a>
+				<em>&raquo;</em> <a href="viewforum.php?f=1958">Обход блокировок</a>
+				<em>&raquo;</em> <a href="viewforum.php?f=659">Обход блокировок на мобильных устройствах</a>
+	</td>
+</tr>
+</table>
+
+<div class="bottom_info hide-for-print">
+
+	<div class="tRight">
+		<span id="jumpbox-wrap"></span>
+	</div>
+
+	<table class="w100">
+	<tr>
+				<td class="tRight med vTop">
+					</td>
+	</tr>
+	</table>
+
+</div><!--/bottom_info-->
+
+
+
+				</div><!--/main_content_wrap-->
+			</td><!--/main_content-->
+
+		</tr>
+		</table>
+	</div><!--/page_content-->
+
+	<!--page_footer-->
+	<div id="page_footer" class="hide-for-print">
+
+		
+		<div class="clear"></div>
+
+		<nav id="footer-info-links">
+			<div>
+				<a href="info.php?show=user_agreement" rel="nofollow">Условия использования</a>
+				&middot;
+				<a href="info.php?show=advert" rel="nofollow">Реклама на сайте</a>
+				&middot;
+				<a href="info.php?show=copyright_holders" rel="nofollow">Для правообладателей</a>
+				&middot;
+				<a href="info.php?show=press" rel="nofollow">Для прессы</a>
+				&middot;
+				<a href="viewtopic.php?t=2234744">Для провайдеров</a>
+				<!--&middot;-->
+				<!--<a href="http://rutracker.news">Блог</a>-->
+				&middot;
+				<a href="https://rutracker.wiki">Торрентопедия</a>
+			</div>
+			<div>
+				<a href="viewtopic.php?t=1045"><b>Правила</b></a>
+				&middot;
+				<a href="/go/8" rel="nofollow">Кому задать вопрос</a>
+				&middot;
+				<a href="viewforum.php?f=1538">Авторские раздачи</a>
+				&middot;
+				<a href="viewforum.php?f=1289">Конкурсы</a>
+				&middot;
+				<a href="viewforum.php?f=2332">Новости &quot;Хранителей&quot; и &quot;Антикваров&quot;</a>
+				&middot;
+				<a href="#" onclick="return post2url('index.php', {rand_rel: 1});" rel="nofollow">Случайная раздача</a>
+			</div>
+		</nav>
+
+		
+		<div class="tCenter nowrap" style="margin: 18px 4px 4px 4px;">
+								</div>
+
+		<div class="footer-bottom-links">
+			<ul class="inlined middot-separated">
+				<li><a href="groupcp.php?g=104792" rel="nofollow" target="_blank">Администрация</a></li>
+				<li><a href="groupcp.php?g=104787" rel="nofollow" target="_blank">Модераторы</a></li>
+				<li><a href="groupcp.php?g=104841" rel="nofollow" target="_blank">Тех. помощь</a></li>
+				<li><a href="https://t.me/rutracker_news" rel="nofollow" target="_blank">Telegram-канал</a></li>
+			</ul>
+			<div class="wide">
+									<script>
+					$(function () {
+						var title = "";
+						var src = "https://counter.yadro.ru/hit?t44.1;r" + encodeURIComponent(document.referrer) +
+							((typeof (screen) == "undefined") ? "" : ";s" + screen.width + "*" + screen.height + "*" + (screen.colorDepth ? screen.colorDepth : screen.pixelDepth)) +
+							";u" + encodeURIComponent(document.URL) + ";h" + encodeURIComponent(title.substring(0, 80)) + ";" + Math.random();
+						$('<img src="' + src + '" alt="">').on('load', function () {
+							$('#liveinternet').append(this);
+						});
+					});
+					</script>
+					<a id="liveinternet" href="https://www.liveinternet.ru/stat/rutracker.org/index.html?lang=ru" target="_blank"></a>
+							</div>
+			<ul class="inlined middot-separated">
+																							</ul>
+		</div>
+
+	</div><!--/page_footer-->
+</div><!--/page_container-->
+
+
+<div id="ajax-loading"><b>Loading...</b></div>
+<div id="ajax-error"><b>Error</b></div>
+<style>
+#bb-alert-box {
+	width: auto;
+	max-width: 800px;
+	line-height: 18px;
+	display: none;
+}
+#bb-alert-msg {
+	min-width: 400px;
+	max-height: 400px;
+	margin: 50px 20px;
+	padding: 10px;
+	overflow: auto;
+	text-align: center;
+}
+.bb-alert-err {
+	color: #7E0000;
+	background: #FFEEEE;
+	box-shadow: 0 0 20px #B85353;
+	font-weight: bold;
+}
+</style>
+<div id="bb-alert-box">
+	<div id="bb-alert-msg"></div>
+</div>
+<div id="modal-blocker"></div>
+
+<script>
+$(function () {
+	if (!BB.hasET() && BB.getUrlParam('view') !== 'print') {
+		BB.navbar.init();
+	}
+});
+</script>
+<div id="nav-panel" class="nav-hidden-arrow hide-for-print">
+	<div id="nav-up" class="nav-btn" title="Вверх">
+		<span class="nav-icon"></span>
+	</div>
+	<div id="nav-settings" class="nav-btn">
+		<span class="nav-icon" title="Настройки"></span>
+		<ul id="nav-opt-menu">
+			<li class="nav-event" data-event="click">Показывать по клику</li>
+			<li class="nav-event" data-event="mouseenter">Показывать по наведению</li>
+		</ul>
+	</div>
+	<div id="nav-down" class="nav-btn" title="Вниз">
+		<span class="nav-icon"></span>
+	</div>
+	<div class="nav-hidden-overlay"></div>
+</div>
+
+	</div><!--/body_container-->
+
+<script>(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML="window.__CF$cv$params={r:'a10651288d84751f',t:'MTc4MjI0NzMyMg=='};var a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);";b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script></body>
+</html>

--- a/core/network/rutracker/src/test/resources/fixtures/forum_index.html
+++ b/core/network/rutracker/src/test/resources/fixtures/forum_index.html
@@ -1,0 +1,721 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+
+<meta charset="Windows-1251">
+	<link rel="canonical" href="https://rutracker.org/forum/index.php?map">
+
+<title>rutracker.org</title>
+
+<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+<link rel="manifest" href="/manifest.json">
+<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
+<meta name="msapplication-TileColor" content="#2b5797">
+<meta name="msapplication-TileImage" content="/mstile-144x144.png">
+<meta name="theme-color" content="#ffffff">
+
+<link rel="search" type="application/opensearchdescription+xml" title="Поиск на RuTracker.org" href="https://static.rutracker.cc/opensearch.xml">
+
+<script>
+window.BB = {
+	cur_domain: location.hostname.replace(/.*?(([a-z0-9-]+\.){1,2}[a-z0-9-]+)$/, '$1'),
+	form_token: '',
+	opt_js: {},
+
+	IS_GUEST: !!'1',
+	IMG_URL: 'https://static.rutracker.cc/templates/v1/images',
+	SMILES_URL: 'https://static.rutracker.cc/smiles',
+	catId: 0,
+	FORUM_ID: 0,
+	parentForumId: 0,
+		COOKIE_MARK: 'bb_mark_read',
+	};
+BB.cookie_defaults = {
+	domain: '.' + BB.cur_domain,
+	path: "/forum/",
+};
+</script>
+<link href="https://static.rutracker.cc/templates/v1/min/eb83350bae3880e4073b81d26294de5d.all.min.css" rel="stylesheet">
+<script src="https://static.rutracker.cc/templates/v1/min/4e695e8ea9cf5a1dcc7aed231b887c51.lib.min.js"></script>
+<script src="https://static.rutracker.cc/templates/v1/min/3b60ab3546ba966484df4c3099b918ab.bb.min.js"></script>
+
+
+
+<style>
+.invisible-el {
+	/* @include element-invisible(); */
+	clip: rect(1px, 1px, 1px, 1px);
+	height: 1px;
+	overflow: hidden;
+	position: absolute !important;
+	width: 1px;
+}
+.hidden, .menu-sub, #ajax-loading, #ajax-error, var.ajax-params, #modal-blocker, .q-post {
+	display: none;
+}
+/**/
+#logo {
+	min-height: auto;
+}
+/**/
+/* temp */
+/* temp end */
+</style>
+
+<noscript>
+	<style>
+	.sp-body {
+		display: block; /* for bots */
+	}
+	</style>
+</noscript>
+
+</head>
+
+<body class="" style="">
+
+<div id="invisible-heap" class="invisible-el"></div>
+<div id="preload" class="invisible-el"></div>
+
+
+
+<div id="body_container">
+
+		<script>
+	if (top != self && !self.location.hostname.match(BB.allowed_translator_hosts)) {
+		$(function () {
+			$('body').html('<h1 style="text-align: center;"><br><br>Похоже, вас пытаются обмануть<br>frame\'s hostname: ' + self.location.hostname + '</h1>');
+			throw new Error('in frame');
+		});
+	}
+		</script>
+
+	<div id="page_container">
+
+		<div id="page_header" class="hide-for-print">
+
+			<div id="main-nav" class="site-nav clearfix">
+				<ul class="inlined middot-separated floatL">
+					<li>
+						<a href="index.php"><b>Главная</b></a>
+					</li>
+					<li>
+													<a href="tracker.php" rel="nofollow"><b>Трекер</b></a>
+											</li>
+					<li>
+						<a href="search.php" rel="nofollow"><b>Поиск</b></a>
+					</li>
+					<li>
+						<a href="groupcp.php" rel="nofollow"><b>Группы</b></a>
+					</li>
+					<li>
+						<a href="https://rutracker.wiki/" target="_blank"><b>FAQ</b></a>
+					</li>
+					<li>
+						<a href="viewtopic.php?t=6812335" style="color: #7b1fa2;"><b>VPN</b></a>
+					</li>
+					<li>
+						<a href="viewtopic.php?t=1045"><b>Правила</b></a>
+					</li>
+					<li>
+						<a href="viewtopic.php?t=6452965" style="color: #880e4f;"><b>Донаты</b></a>
+					</li>
+									</ul>
+											</div>
+			<!--/main-nav-->
+
+			
+			<div id="logo">
+				<table style="">
+				<tr>
+					<td id="logo-td" style="padding: 3px 7px 3px 15px;">
+						<a href="index.php" class="site-logo-link">
+								<img class="site-logo"
+		src="https://static.rutracker.cc/logo/logo-3.svg"
+		style=""
+		alt="logo">
+							</a>
+					</td>
+					<td class="tCenter w100" style="padding: 6px 10px 0 3px;">
+											</td>
+				</tr>
+				</table>
+			</div>
+			<!--/logo-->
+
+						<div class="topmenu">
+				<table class="w100">
+				<tr>
+					
+					<td class="tCenter pad_2 nowrap">
+						<div>
+															<a href="profile.php?mode=register" rel="nofollow"><b>Регистрация</b></a>
+								&nbsp;&#0183;&nbsp;
+								<a href="#" onclick="BB.toggle_top_login(); return false;" tabindex="5"><b>Вход</b></a>
+
+								<div id="top-login-box">
+									<form id="quick-search-guest" method="get" action="tracker.php">
+										<input id="search-text-guest" type="text" name="nm" value="" tabindex="1" accesskey="q">
+										<input type="submit" value="поиск" tabindex="2">
+									</form>
+									<form id="login-form-quick" method="post" action="login.php" style="display: none;">
+																				<input id="top-login-uname" type="text" name="login_username" tabindex="1" accesskey="l" placeholder="имя">
+										<input id="top-login-pwd" type="password" name="login_password" tabindex="2" placeholder="пароль">
+										<label title="Защищенное соединение" class="login-ssl-block" style="display: none;">
+											<input class="login-ssl" type="checkbox" tabindex="3" checked>SSL
+										</label>
+										<input id="top-login-btn" type="submit" name="login" value="вход" tabindex="4">
+									</form>
+								</div>
+
+								<a href="otp.php" rel="nofollow"><b>Забыли имя или пароль?</b></a>
+													</div>
+					</td>
+
+					
+				</tr>
+				</table>
+			</div><!--/topmenu-->
+			
+			
+		</div>
+		<!--/page_header-->
+
+		
+		<div id="page_content">
+			<table style="width: 100%; border: none;">
+			<tr>
+
+								<td id="sidebar1">
+					<div id="sidebar1_wrap">
+
+	
+	<div>
+		<h3>FAQ</h3>
+		<ul class="med">
+			<li>
+				<a href="viewtopic.php?t=1045"><b style="color: brown;">Правила</b></a>
+				/
+				<a href="/go/1" rel="nofollow" target="_blank"><b style="color: brown;">Как тут качать</b></a>
+			</li>
+			<li><a href="/go/10" rel="nofollow" target="_blank">Основные понятия</a></li>
+			<li><a href="/go/5" rel="nofollow" target="_blank">Общие вопросы</a></li>
+			<li><a href="/go/6" rel="nofollow" target="_blank">Что такое torrent (торрент)</a></li>
+			<li><a href="/go/11" rel="nofollow" target="_blank">Как пользоваться Поиском</a></li>
+			<li><a href="/go/8" rel="nofollow" target="_blank">Кому задать вопрос</a></li>
+		</ul>
+	</div>
+
+	
+	<div>
+		<h3>FAQ</h3>
+		<ul class="med">
+			<li><a href="/go/7" rel="nofollow" target="_blank"><b>Как создать раздачу</b></a></li>
+			<li><a href="/go/9" rel="nofollow" target="_blank">Как залить картинку</a></li>
+			<li><a href="viewtopic.php?t=971472">Угнали аккаунт / забанили?</a></li>
+			<li><a href="/go/13" rel="nofollow" target="_blank">Как почистить кеш и куки</a></li>
+			<li><a href="/go/14" rel="nofollow" target="_blank">Как перезалить торрент-файл</a></li>
+			<li><a href="viewtopic.php?t=964118">Хочу лычку!</a></li>
+		</ul>
+	</div>
+
+	
+	<div>
+		<h3>BitTorrent клиенты</h3>
+		<ul>
+			<li><a href="viewtopic.php?t=2965837"><b style="color: brown;">Несовместимые с трекером</b></a></li>
+			<li><a href="viewforum.php?f=329" class="med"><b>uTorrent</b></a></li>
+			<li><a href="viewforum.php?f=336">Другие BitTorrent клиенты</a></li>
+			<li><a href="viewforum.php?f=353">Клиенты под Linux</a></li>
+			<li><a href="/go/12" rel="nofollow" target="_blank">Как настроить клиент на максимальную скорость</a></li>
+		</ul>
+	</div>
+
+	<div>
+		<h3>FAQ</h3>
+		<ul class="med">
+			<li><a href="viewforum.php?f=23">Обработка аудио и видео</a></li>
+			<li><a href="/go/19" rel="nofollow" target="_blank">Настройки роутеров и файерволлов</a></li>
+			<li><a href="/go/20" rel="nofollow" target="_blank">Решение проблем с компьютерами</a></li>
+			<li><a href="/go/21" rel="nofollow" target="_blank">Хеш-сумма и магнет-ссылки</a></li>
+			<li><a href="/go/22" rel="nofollow" target="_blank">FAQ по учёту статистики</a></li>
+		</ul>
+	</div>
+
+	<div class="tr_main_cats">
+		<h3>Кино, Видео, ТВ</h3>
+		<ul>
+			<li><a href="viewforum.php?f=7">Фильмы</a>, <a href="viewforum.php?f=22">Наше кино</a>, <a href="viewforum.php?f=511">Театр</a></li>
+			<li><a href="viewforum.php?f=124">Арт-хаус и авторское кино</a></li>
+			<li><a href="viewforum.php?f=93">DVD</a>, <a href="viewforum.php?f=2198">HD</a>, <a href="viewforum.php?f=352">3D</a></li>
+			<li><a href="viewforum.php?f=46">Док. фильмы</a>, <a href="viewforum.php?f=255">Спорт</a></li>
+			<li><a href="viewforum.php?f=33">Аниме</a>, <a href="viewforum.php?f=4">Мультфильмы</a></li>
+			<li><a href="viewforum.php?f=921">Мультсериалы</a>, <a href="viewforum.php?f=24">Юмор</a></li>
+			<li><a href="index.php?c=18" rel="nofollow">Сериалы</a></li>
+		</ul>
+	</div>
+
+	<div class="tr_main_cats">
+		<h3>Книги, Ин. языки, Уроки</h3>
+		<ul>
+			<li><a href="index.php?c=25" rel="nofollow">Книги</a>, <a href="index.php?c=33">Аудиокниги</a></li>
+			<li><a href="index.php?c=10" rel="nofollow">Обучающее видео</a></li>
+			<li><a href="index.php?c=34" rel="nofollow">Ин. языки</a>, <a href="viewforum.php?f=610">Видеоуроки</a></li>
+		</ul>
+	</div>
+
+	<div class="tr_main_cats">
+		<h3>Музыка, Ноты, Караоке</h3>
+		<ul>
+			<li><a href="index.php?c=22" rel="nofollow">Рок музыка</a></li>
+			<li><a href="viewforum.php?f=409">Классическая музыка</a></li>
+			<li><a href="index.php?c=31" rel="nofollow">Джаз и Блюз</a>, <a href="index.php?c=35">Поп музыка</a></li>
+			<li><a href="viewforum.php?f=1125">Фольклор</a></li>
+			<li><a href="viewforum.php?f=408">Рэп, Хип-Хоп, R'n'B</a></li>
+			<li><a href="index.php?c=23" rel="nofollow">Электронная музыка</a></li>
+			<li><a href="viewforum.php?f=416">Саундтреки и Караоке</a></li>
+			<li><a href="viewforum.php?f=1215">Шансон, Авторская песня</a></li>
+			<li><a href="viewforum.php?f=919">Ноты и Либретто</a></li>
+			<li><a href="index.php?c=39">Музыкальное видео</a></li>
+		</ul>
+	</div>
+
+	<div class="tr_main_cats">
+		<h3>Игры, Программы, КПК</h3>
+		<ul>
+			<li><a href="viewforum.php?f=1933">iOS</a>, <a href="viewforum.php?f=1376">Linux</a>, <a href="viewforum.php?f=1366">Macintosh</a></li>
+			<li><a href="viewforum.php?f=5">Игры для Windows</a>
+			<li><a href="viewforum.php?f=548">Игры для консолей</a></li>
+			<li><a href="viewforum.php?f=1012">Операционные системы</a></li>
+			<li><a href="viewforum.php?f=1013">Системные программы</a></li>
+			<li><a href="viewforum.php?f=1052">Веб-разработка</a>, <a href="viewforum.php?f=828">Клипарты</a></li>
+			<li><a href="viewforum.php?f=1016">Мультимедиа и 3D контент</a></li>
+			<li><a href="viewforum.php?f=285">Мобильные тел. и КПК</a></li>
+			<li><a href="viewforum.php?f=10">Разное</a></li>
+		</ul>
+	</div>
+
+	
+</div><!--/sidebar1_wrap-->
+				</td><!--/sidebar1-->
+				
+				<td id="main_content">
+					<div id="main_content_wrap">
+
+																		<script>
+						//$(function(){
+						//	$('#news-t-5115937').addClass('new');
+						//});
+						</script>
+												<div id="latest_news">
+							<table class="w100">
+							<tr>
+								<td class="w100">
+									<h3>Новости трекера</h3>
+									<table id="latest-news-table">
+																		<tr>
+										<td>
+											<div class="news_date">05-Июн</div>
+										</td>
+										<td class="w100">
+											<div id="news-t-6867103" class="news_title">
+												<a href="viewtopic.php?t=6867103">Чемпионат Мира 2026 (FIFA World Cup 2026)</a>
+											</div>
+										</td>
+									</tr>
+																		<tr>
+										<td>
+											<div class="news_date">09-Дек</div>
+										</td>
+										<td class="w100">
+											<div id="news-t-6785008" class="news_title">
+												<a href="viewtopic.php?t=6785008">Новогодний раздел</a>
+											</div>
+										</td>
+									</tr>
+																		<tr>
+										<td>
+											<div class="news_date">18-Сен</div>
+										</td>
+										<td class="w100">
+											<div id="news-t-6745938" class="news_title">
+												<a href="viewtopic.php?t=6745938">18 сентября - День Рождения Рутрекера</a>
+											</div>
+										</td>
+									</tr>
+																		<tr>
+										<td>
+											<div class="news_date">11-Дек</div>
+										</td>
+										<td class="w100">
+											<div id="news-t-6612140" class="news_title">
+												<a href="viewtopic.php?t=6612140">Новогодний раздел</a>
+											</div>
+										</td>
+									</tr>
+																		<tr>
+										<td>
+											<div class="news_date">18-Сен</div>
+										</td>
+										<td class="w100">
+											<div id="news-t-6574632" class="news_title">
+												<a href="viewtopic.php?t=6574632">У Рутрекера юбилей - 20 лет!</a>
+											</div>
+										</td>
+									</tr>
+																		</table>
+								</td>
+								<td style="padding: 2px;" class="vMiddle">
+																	</td>
+							</tr>
+							</table>
+						</div><!--/latest_news-->
+						
+						
+						
+						
+						<!--/page_header.tpl-->
+<div id="forums_list_wrap">
+
+	<div id="forums_top_links" class="clearfix">
+		<ul class="inlined middot-separated floatL">
+			<li><a href="index.php?map" class="med bold"><img class="feed-small" src="https://static.rutracker.cc/templates/v1/images/feed_1.png" alt="f"> Карта форумов</a></li>
+			<li>
+				<a href="http://feed.rutracker.cc/atom/f/0.atom" class="med" target="_blank"><img class="feed-small" src="https://static.rutracker.cc/templates/v1/images/feed_1.png" alt="a"> Последние раздачи</a>
+			</li>
+					</ul>
+			</div><!--/forums_top_links-->
+
+	
+	<div id="forums_wrap">
+
+		<table class="w100">
+		<tr>
+			<td id="categories-wrap">
+								<style>
+#f-map a {
+	font-size: 12px;
+	text-decoration: none;
+	padding-left: 8px;
+}
+#f-map li {
+	margin: 4px 0 0 6px;
+}
+#f-map .b {
+	font-weight: bold;
+}
+ul.tree-root {
+	margin-left: 0;
+}
+ul.tree-root > li > ul {
+	margin-left: 0;
+}
+ul.tree-root li {
+	list-style: none;
+}
+ul.tree-root > li {
+	padding: 0;
+	margin-left: 0 !important;
+}
+.c-title {
+	display: block;
+	margin: 9px 0;
+	padding: 0 0 5px 5px;
+	border-bottom: 1px solid #B7C0C5;
+	color: #800000;
+	font-size: 13px;
+	font-weight: bold;
+	letter-spacing: 1px;
+}
+ul.tree-root img {
+	cursor: pointer;
+}
+a.hl, a.hl:visited {
+	color: #1515FF;
+}
+</style>
+
+<script>
+$(function () {
+	function qs_highlight_found() {
+		this.style.display = '';
+		var a = $('a:first', this)[0];
+		var q = $('#q-search').val().toLowerCase();
+		if (q != '' && a.innerHTML.toLowerCase().indexOf(q) != -1) {
+			a.className = 'hl';
+		} else {
+			a.className = '';
+		}
+	}
+
+	$(document).on('click', 'img.open-feed-icon', function openFeed() {
+		$('#feed-id').val(this.dataset.f_id);
+		$('#feed-form').submit();
+	});
+
+	$('#q-search').focus().quicksearch('#f-map li', {
+		delay: 300,
+		noResults: '#f-none',
+		show: qs_highlight_found,
+		onAfter: function () {
+			$('#f-load').hide();
+			$('#f-map').show();
+		},
+	});
+	$.each($('#f-map a'), function (i, a) {
+		var f_id = $(a).attr('href');
+		$(a)
+			.attr('href', 'viewforum.php?f=' + f_id)
+			.before('<img class="feed-small open-feed-icon" src="https://static.rutracker.cc/templates/v1/images/feed_1.png" data-f_id="' + f_id + '" alt="feed">')
+		;
+		if (f_id == 566) {
+			$(a).attr({ href: 'https://rutracker.wiki/', target: '_blank' })
+				.css('padding-left', '20px')
+				.siblings('img').remove();
+		}
+	});
+	$.each($('span.c-title'), function (i, el) {
+		$(el).text(this.title);
+		this.title = '';
+	});
+});
+</script>
+
+<form id="feed-form" method="post" action="feed.php" target="_blank" style="display: none;">
+	<input type="hidden" name="mode" value="get_feed_url">
+	<input type="hidden" name="type" value="f">
+	<input id="feed-id" type="hidden" name="id" value="">
+</form>
+
+<div class="f-map-wrap row1 pad_8">
+	<div style="margin: 20px auto; display: table;">
+
+		<div style="padding: 0 0 12px 3px;">
+			<form autocomplete="off">
+				<i>Фильтр по названию:</i> &nbsp;<input type="text" id="q-search" style="width: 200px;">
+			</form>
+			<div id="f-none" style="padding: 25px 0 0 0; display: none;">Не найдено</div>
+		</div>
+
+		<div id="f-load" style="padding: 6px;"><i class="loading-1">загружается...</i></div>
+		<div id="f-map" style="display: none;">
+			<ul class='tree-root'><li><span class='b'><span class="c-title" title="ОБХОД БЛОКИРОВОК"></span></span><ul><li><span class='b'><a href="1649">VPN-сервисы</a></span></li><li><span class='b'><a href="1958">Обход блокировок</a></span><ul><li><span><a href="989">Плагины для браузеров</a></span></li><li><span><a href="2260">Блокировка bt, способы обхода и обсуждение</a></span></li><li><span><a href="2066">TOR, I2P, ONION и другие распределенные сети</a></span></li><li><span><a href="659">Обход блокировок на мобильных устройствах</a></span></li><li><span><a href="616">Другие способы</a></span></li><li><span><a href="2197">Раздел для жалоб (недоступность Рутрекера вне РФ)</a></span></li><li><span><a href="748">Мой.Рутрекер</a></span></li><li><span><a href="1405">Архив (Обход блокировок)</a></span></li></ul></li></ul></li></ul>
+<ul class='tree-root'><li><span class='b'><span class="c-title" title="Товары, услуги, игры и развлечения"></span></span><ul><li><span class='b'><a href="638">Браузерные и клиентские онлайн-игры</a></span></li><li><span class='b'><a href="2346">Магазины и образование</a></span><ul><li><span><a href="928">AliExpress</a></span></li><li><span><a href="551">Решение проблем и общие вопросы о покупках</a></span></li><li><span><a href="246">Покупки (архив)</a></span></li><li><span><a href="925">Оффтоп</a></span></li></ul></li></ul></li></ul>
+<ul class='tree-root'><li><span class='b'><span class="c-title" title="Новости"></span></span><ul><li><span class='b'><a href="1960">Новости трекера</a></span><ul><li><span><a href="1628">Обсуждение новостей трекера</a></span></li><li><span><a href="1538">Авторские раздачи</a></span></li><li><span><a href="2332">Новости &quot;Хранителей&quot; и &quot;Антикваров&quot;</a></span></li><li><span><a href="1416">Архив (Новости трекера)</a></span></li></ul></li><li><span class='b'><a href="1678">Краудфандинг (переводы, покупка дисков и т. п.)</a></span><ul><li><span><a href="2390">Подфорум для общих сборов</a></span></li><li><span><a href="992">Переводы: фильмы, мультфильмы, сериалы - Авторские переводчики</a></span></li><li><span><a href="1000">Архив (Краудфандинг)</a></span></li></ul></li><li><span class='b'><a href="1246">GENERATION.TORRENT - Музыкальный конкурс</a></span></li><li><span class='b'><a href="1289">Rutracker Awards (мероприятия и конкурсы)</a></span><ul><li><span><a href="2317">Конкурсы</a></span></li><li><span><a href="25">Доска почета!</a></span></li><li><span><a href="2105">Конкурсы спортивных прогнозов</a></span></li><li><span><a href="2214">Rutracker Awards (Раздачи)</a></span></li><li><span><a href="1579">Фотоклуб. Весь мир на ладони</a></span></li><li><span><a href="2213">Архив (Rutracker Awards)</a></span></li><li><span><a href="203">Архив (Конкурсы спортивных прогнозов)</a></span></li></ul></li></ul></li></ul>
+<ul class='tree-root'><li><span class='b'><span class="c-title" title="Вопросы по форуму и трекеру"></span></span><ul><li><span class='b'><a href="566">Правила, основные инструкции, FAQ-и</a></span></li><li><span class='b'><a href="2">Вопросы по форуму и трекеру</a></span><ul><li><span><a href="571">Предложения по улучшению форума и трекера</a></span></li><li><span><a href="679">Архив (Вопросы по форуму и трекеру)</a></span></li></ul></li><li><span class='b'><a href="328">Вопросы по BitTorrent сети и ее клиентам</a></span><ul><li><span><a href="1231">Архив (Вопросы по BitTorrent сети и ее клиентам)</a></span></li><li><span><a href="676">Проблемы со скоростью скачивания и отдачи</a></span></li><li><span><a href="1465">Настройка антивирусов и файерволов</a></span></li><li><span><a href="329">µTorrent и BitTorrent</a></span></li><li><span><a href="336">Другие BitTorrent клиенты</a></span></li><li><span><a href="353">Клиенты под Linux</a></span></li><li><span><a href="338">Клиенты для Mac OS</a></span></li><li><span><a href="1364">Торрент-клиенты для мобильных устройств</a></span></li></ul></li><li><span class='b'><a href="326">Обсуждение провайдеров</a></span><ul><li><span><a href="350">Дом.ru (ЭР-Телеком)</a></span></li><li><span><a href="351">Билайн</a></span></li><li><span><a href="349">ТТК (ТрансТелеКом)</a></span></li><li><span><a href="2340">Провайдеры Москвы и Московской области</a></span></li><li><span><a href="804">Провайдеры Санкт-Петербурга и Ленинградской области</a></span></li><li><span><a href="810">Провайдеры Украины</a></span></li><li><span><a href="382">Провайдеры Беларуси</a></span></li><li><span><a href="1118">Провайдеры Казахстана</a></span></li><li><span><a href="1119">Провайдеры Прибалтики</a></span></li><li><span><a href="383">Провайдеры Израиля</a></span></li><li><span><a href="385">Провайдеры Германии</a></span></li><li><span><a href="587">Беспроводной интернет в РФ</a></span></li><li><span><a href="379">Провайдеры Екатеринбурга</a></span></li><li><span><a href="583">Ростелеком/ОнЛайм (Москва)</a></span></li><li><span><a href="582">Ростелеком (регионы)</a></span></li><li><span><a href="384">Netbynet</a></span></li><li><span><a href="327">МТС (СТРИМ)</a></span></li><li><span><a href="1244">Архив (Обсуждение провайдеров)</a></span></li></ul></li><li><span class='b'><a href="1146">Железо: комплектующие и периферия</a></span><ul><li><span><a href="1598">Железо: комплексные проблемы</a></span></li><li><span><a href="1599">Подбор конфигурации, выбор и обсуждение комплектующих</a></span></li><li><span><a href="1652">Сетевое оборудование</a></span></li><li><span><a href="1600">Выбор и обсуждение периферии</a></span></li><li><span><a href="1601">Мобильные устройства</a></span></li><li><span><a href="1602">Модификации</a></span></li><li><span><a href="1603">Прочие устройства</a></span></li><li><span><a href="1604">Архив (Железо: комплектующие и периферия)</a></span></li></ul></li></ul></li></ul>
+<ul class='tree-root'><li><span class='b'><span class="c-title" title="Кино, Видео и ТВ"></span></span><ul><li><span class='b'><a href="756">Предложения по улучшению категории &quot;Кино, Видео и ТВ&quot;</a></span></li><li><span class='b'><a href="214">Кино, Видео и TV - помощь по разделу</a></span><ul><li><span><a href="692">Заявки, заказы, координация</a></span></li><li><span><a href="1253">Архив (Кино, Видео и TV - помощь по разделу)</a></span></li><li><span><a href="23">Обработка видео + аудио</a></span></li><li><span><a href="707">Работа с DVD</a></span></li><li><span><a href="1194">Работа с BLU RAY и HD-DVD</a></span></li></ul></li><li><span class='b'><a href="22">Наше кино</a></span><ul><li><span><a href="941">Кино СССР</a></span></li><li><span><a href="1666">Детские отечественные фильмы</a></span></li><li><span><a href="376">Авторские дебюты</a></span></li><li><span><a href="106">Фильмы России и СССР на национальных языках [без перевода]</a></span></li><li><span><a href="772">Российские/советские режиссёры и их творчество</a></span></li><li><span><a href="789">Российские/советские актёры и фильмы с их участием</a></span></li><li><span><a href="65">Ищу (Наше кино) + Тематические ссылки</a></span></li><li><span><a href="267">Архив (Наше кино)</a></span></li></ul></li><li><span class='b'><a href="7">Зарубежное кино</a></span><ul><li><span><a href="1640">Тематические подборки ссылок</a></span></li><li><span><a href="187">Классика мирового кинематографа</a></span></li><li><span><a href="2090">Фильмы до 1990 года</a></span></li><li><span><a href="2221">Фильмы 1991-2000</a></span></li><li><span><a href="2091">Фильмы 2001-2005</a></span></li><li><span><a href="2092">Фильмы 2006-2010</a></span></li><li><span><a href="2093">Фильмы 2011-2015</a></span></li><li><span><a href="2200">Фильмы 2016-2020</a></span></li><li><span><a href="1950">Фильмы 2021-2025</a></span></li><li><span><a href="252">Фильмы 2026</a></span></li><li><span><a href="2540">Фильмы ближнего зарубежья</a></span></li><li><span><a href="934">Азиатские фильмы</a></span></li><li><span><a href="505">Индийское кино</a></span></li><li><span><a href="212">Сборники фильмов</a></span></li><li><span><a href="2459">Короткий метр</a></span></li><li><span><a href="1235">Грайндхаус</a></span></li><li><span><a href="166">Зарубежные фильмы без перевода</a></span></li><li><span><a href="185">Звуковые дорожки и Переводы</a></span></li><li><span><a href="1454">Авторский перевод</a></span></li><li><span><a href="2374">Закадровый перевод</a></span></li><li><span><a href="1692">Подраздел переводчиков</a></span></li><li><span><a href="2373">Профессиональные студии закадрового перевода и дубляжа</a></span></li><li><span><a href="254">Зарубежные актёры и фильмы с их участием</a></span></li><li><span><a href="771">Зарубежные режиссёры и их творчество</a></span></li><li><span><a href="44">Поиск и обсуждение фильмов</a></span></li><li><span><a href="906">Ищу / Предлагаю звуковые дорожки и переводы</a></span></li><li><span><a href="69">Архив (Зарубежное кино)</a></span></li></ul></li><li><span class='b'><a href="124">Арт-хаус и авторское кино</a></span><ul><li><span><a href="1543">Короткий метр (Арт-хаус и авторское кино)</a></span></li><li><span><a href="709">Документальные фильмы (Арт-хаус и авторское кино)</a></span></li><li><span><a href="1577">Анимация (Арт-хаус и авторское кино)</a></span></li><li><span><a href="149">Фильмографии (Авторское кино)</a></span></li><li><span><a href="125">Ищу / Предлагаю (Авторское кино)</a></span></li><li><span><a href="186">Поговорим об арт-хаусе</a></span></li><li><span><a href="531">Архив (Авторское кино)</a></span></li></ul></li><li><span class='b'><a href="511">Театр</a></span><ul><li><span><a href="1493">Спектакли без перевода</a></span></li><li><span><a href="540">Архив (Театр)</a></span></li><li><span><a href="513">Ищу / Предлагаю (Театр)</a></span></li></ul></li><li><span class='b'><a href="93">DVD Video</a></span><ul><li><span><a href="96">Архив (DVD, HD Video)</a></span></li><li><span><a href="94">Ищу / Предлагаю (DVD, HD Video)</a></span></li><li><span><a href="905">Классика мирового кинематографа (DVD Video)</a></span></li><li><span><a href="101">Зарубежное кино (DVD Video)</a></span></li><li><span><a href="100">Наше кино (DVD Video)</a></span></li><li><span><a href="877">Фильмы Ближнего Зарубежья (DVD Video)</a></span></li><li><span><a href="1576">Азиатские фильмы (DVD Video)</a></span></li><li><span><a href="572">Арт-хаус и авторское кино (DVD Video)</a></span></li><li><span><a href="2220">Индийское кино (DVD Video)</a></span></li><li><span><a href="1670">Грайндхаус (DVD Video)</a></span></li></ul></li><li><span class='b'><a href="2198">HD Video</a></span><ul><li><span><a href="2199">Классика мирового кинематографа (HD Video)</a></span></li><li><span><a href="313">Зарубежное кино (HD Video)</a></span></li><li><span><a href="312">Наше кино (HD Video)</a></span></li><li><span><a href="1247">Фильмы Ближнего Зарубежья (HD Video)</a></span></li><li><span><a href="2201">Азиатские фильмы (HD Video)</a></span></li><li><span><a href="2339">Арт-хаус и авторское кино (HD Video)</a></span></li><li><span><a href="140">Индийское кино (HD Video)</a></span></li><li><span><a href="194">Грайндхаус (HD Video)</a></span></li><li><span><a href="653">Анонсы (U)HD Video</a></span></li></ul></li><li><span class='b'><a href="718">UHD Video</a></span><ul><li><span><a href="775">Классика мирового кинематографа (UHD Video)</a></span></li><li><span><a href="1457">Зарубежное кино (UHD Video)</a></span></li><li><span><a href="1940">Наше кино (UHD Video)</a></span></li><li><span><a href="272">Азиатские фильмы (UHD Video)</a></span></li><li><span><a href="271">Арт-хаус и авторское кино (UHD Video)</a></span></li></ul></li><li><span class='b'><a href="352">3D/Стерео Кино, Видео, TV и Спорт</a></span><ul><li><span><a href="2344">Архив (3D)</a></span></li><li><span><a href="549">3D Кинофильмы</a></span></li><li><span><a href="1213">3D Мультфильмы</a></span></li><li><span><a href="2109">3D Документальные фильмы</a></span></li><li><span><a href="514">3D Спорт</a></span></li><li><span><a href="2097">3D Ролики, Музыкальное видео, Трейлеры к фильмам</a></span></li></ul></li><li><span class='b'><a href="4">Мультфильмы</a></span><ul><li><span><a href="84">Мультфильмы (UHD Video)</a></span></li><li><span><a href="2343">Отечественные мультфильмы (HD Video)</a></span></li><li><span><a href="930">Иностранные мультфильмы (HD Video)</a></span></li><li><span><a href="2365">Иностранные короткометражные мультфильмы (HD Video)</a></span></li><li><span><a href="1900">Отечественные мультфильмы (DVD)</a></span></li><li><span><a href="2258">Иностранные короткометражные мультфильмы (DVD)</a></span></li><li><span><a href="521">Иностранные мультфильмы (DVD)</a></span></li><li><span><a href="208">Отечественные мультфильмы</a></span></li><li><span><a href="539">Отечественные полнометражные мультфильмы</a></span></li><li><span><a href="2183">Мультфильмы Ближнего Зарубежья</a></span></li><li><span><a href="209">Иностранные мультфильмы</a></span></li><li><span><a href="484">Иностранные короткометражные мультфильмы</a></span></li><li><span><a href="822">Сборники мультфильмов</a></span></li><li><span><a href="181">Мультфильмы без перевода</a></span></li><li><span><a href="86">Ищу (Мультфильмы)</a></span></li><li><span><a href="665">Архив (Мультфильмы)</a></span></li></ul></li><li><span class='b'><a href="921">Мультсериалы</a></span><ul><li><span><a href="815">Мультсериалы (SD Video)</a></span></li><li><span><a href="816">Мультсериалы (DVD Video)</a></span></li><li><span><a href="1460">Мультсериалы (HD Video)</a></span></li><li><span><a href="498">Мультсериалы (UHD Video)</a></span></li><li><span><a href="932">Ищу (Мультсериалы)</a></span></li><li><span><a href="931">Архив (Мультсериалы)</a></span></li></ul></li><li><span class='b'><a href="33">Аниме</a></span><ul><li><span><a href="1385">Предложения по улучшению раздела &quot;Аниме&quot;</a></span></li><li><span><a href="705">Поговорим об аниме</a></span></li><li><span><a href="1106">Онгоинги (HD Video)</a></span></li><li><span><a href="1105">Аниме (HD Video)</a></span></li><li><span><a href="599">Аниме (DVD Video)</a></span></li><li><span><a href="1389">Аниме (SD Video)</a></span></li><li><span><a href="1391">Аниме (плеерный подраздел)</a></span></li><li><span><a href="2491">Аниме (QC подраздел)</a></span></li><li><span><a href="2544">Ван-Пис</a></span></li><li><span><a href="1642">Гандам</a></span></li><li><span><a href="1390">Наруто</a></span></li><li><span><a href="404">Покемоны</a></span></li><li><span><a href="1277">Дунхуа и Эни</a></span></li><li><span><a href="809">Звуковые дорожки и Переводы (Аниме)</a></span></li><li><span><a href="2484">Артбуки и журналы (Аниме)</a></span></li><li><span><a href="1386">Обои, сканы, аватары, арт</a></span></li><li><span><a href="1387">AMV и другие ролики</a></span></li><li><span><a href="535">Архив (Аниме)</a></span></li></ul></li></ul></li></ul>
+<ul class='tree-root'><li><span class='b'><span class="c-title" title="Сериалы"></span></span><ul><li><span class='b'><a href="917">Предложения по улучшению категории &quot;Сериалы&quot;</a></span></li><li><span class='b'><a href="9">Русские сериалы</a></span><ul><li><span><a href="26">Ищу (Русские сериалы)</a></span></li><li><span><a href="32">Обсуждение (Русские сериалы)</a></span></li><li><span><a href="81">Русские сериалы (HD Video)</a></span></li><li><span><a href="920">Русские сериалы (DVD Video)</a></span></li><li><span><a href="80">Сельский детектив</a></span></li><li><span><a href="1535">По законам военного времени</a></span></li><li><span><a href="188">Московские тайны</a></span></li><li><span><a href="91">Я знаю твои секреты</a></span></li><li><span><a href="990">Универ / Универ. Новая общага / СашаТаня</a></span></li><li><span><a href="1408">Женская версия</a></span></li><li><span><a href="175">След</a></span></li><li><span><a href="79">Некрасивая подружка</a></span></li><li><span><a href="104">Психология преступления</a></span></li><li><span><a href="67">Архив (Русские сериалы)</a></span></li></ul></li><li><span class='b'><a href="189">Зарубежные сериалы</a></span><ul><li><span><a href="1147">Обсуждение сериалов</a></span></li><li><span><a href="191">Ищу (Зарубежные сериалы)</a></span></li><li><span><a href="842">Новинки и сериалы в стадии показа</a></span></li><li><span><a href="235">Сериалы США и Канады</a></span></li><li><span><a href="242">Сериалы Великобритании и Ирландии</a></span></li><li><span><a href="819">Скандинавские сериалы</a></span></li><li><span><a href="1531">Испанские сериалы</a></span></li><li><span><a href="721">Итальянские сериалы</a></span></li><li><span><a href="1102">Европейские сериалы</a></span></li><li><span><a href="1120">Сериалы стран Африки, Ближнего и Среднего Востока</a></span></li><li><span><a href="1214">Сериалы Австралии и Новой Зеландии</a></span></li><li><span><a href="489">Сериалы Ближнего Зарубежья</a></span></li><li><span><a href="387">Сериалы совместного производства нескольких стран</a></span></li><li><span><a href="1359">Веб-сериалы, Вебизоды к сериалам и Пилотные серии сериалов</a></span></li><li><span><a href="184">Бесстыжие / Shameless (US)</a></span></li><li><span><a href="1171">Викинги / Vikings</a></span></li><li><span><a href="1417">Во все тяжкие / Breaking Bad</a></span></li><li><span><a href="625">Доктор Хаус / House M.D.</a></span></li><li><span><a href="1449">Игра престолов / Game of Thrones</a></span></li><li><span><a href="273">Карточный Домик / House of Cards</a></span></li><li><span><a href="504">Клан Сопрано / The Sopranos</a></span></li><li><span><a href="372">Сверхъестественное / Supernatural</a></span></li><li><span><a href="110">Секретные материалы / The X-Files</a></span></li><li><span><a href="121">Твин пикс / Twin Peaks</a></span></li><li><span><a href="507">Теория большого взрыва + Детство Шелдона</a></span></li><li><span><a href="536">Форс-мажоры / Костюмы в законе / Suits</a></span></li><li><span><a href="1144">Ходячие мертвецы + Бойтесь ходячих мертвецов</a></span></li><li><span><a href="173">Черное зеркало / Black Mirror</a></span></li><li><span><a href="195">Для некондиционных раздач</a></span></li><li><span><a href="190">Архив (Зарубежные сериалы)</a></span></li></ul></li><li><span class='b'><a href="2366">Зарубежные сериалы (HD Video)</a></span><ul><li><span><a href="119">Зарубежные сериалы (UHD Video)</a></span></li><li><span><a href="1803">Новинки и сериалы в стадии показа (HD Video)</a></span></li><li><span><a href="266">Сериалы США и Канады (HD Video)</a></span></li><li><span><a href="193">Сериалы Великобритании и Ирландии (HD Video)</a></span></li><li><span><a href="1690">Скандинавские сериалы (HD Video)</a></span></li><li><span><a href="1459">Европейские сериалы (HD Video)</a></span></li><li><span><a href="1463">Сериалы стран Африки, Ближнего и Среднего Востока (HD Video)</a></span></li><li><span><a href="825">Сериалы Австралии и Новой Зеландии (HD Video)</a></span></li><li><span><a href="1248">Сериалы Ближнего Зарубежья (HD Video)</a></span></li><li><span><a href="1288">Сериалы совместного производства нескольких стран (HD Video)</a></span></li><li><span><a href="1669">Викинги / Vikings (HD Video)</a></span></li><li><span><a href="2393">Доктор Хаус / House M.D. (HD Video)</a></span></li><li><span><a href="265">Игра престолов / Game of Thrones (HD Video)</a></span></li><li><span><a href="2406">Карточный домик (HD Video)</a></span></li><li><span><a href="2404">Сверхъестественное / Supernatural (HD Video)</a></span></li><li><span><a href="2405">Секретные материалы / The X-Files (HD Video)</a></span></li><li><span><a href="2370">Твин пикс / Twin Peaks (HD Video)</a></span></li><li><span><a href="2396">Теория Большого Взрыва / The Big Bang Theory (HD Video)</a></span></li><li><span><a href="2398">Ходячие мертвецы + Бойтесь ходячих мертвецов (HD Video)</a></span></li><li><span><a href="1949">Черное зеркало / Black Mirror (HD Video)</a></span></li><li><span><a href="1498">Для некондиционных раздач (HD Video)</a></span></li><li><span><a href="2369">Архив Зарубежные сериалы (HD Video)</a></span></li></ul></li><li><span class='b'><a href="911">Сериалы Латинской Америки, Турции и Индии</a></span><ul><li><span><a href="914">Ищу / Предлагаю</a></span></li><li><span><a href="325">Сериалы Аргентины</a></span></li><li><span><a href="534">Сериалы Бразилии</a></span></li><li><span><a href="594">Сериалы Венесуэлы</a></span></li><li><span><a href="1301">Сериалы Индии</a></span></li><li><span><a href="607">Сериалы Колумбии</a></span></li><li><span><a href="1574">Сериалы Латинской Америки с озвучкой (раздачи папками)</a></span></li><li><span><a href="1539">Сериалы Латинской Америки с субтитрами</a></span></li><li><span><a href="694">Сериалы Мексики</a></span></li><li><span><a href="781">Сериалы совместного производства</a></span></li><li><span><a href="704">Сериалы Турции</a></span></li><li><span><a href="1537">Для некондиционных раздач</a></span></li><li><span><a href="913">Архив (Сериалы Латинской Америки, Турции и Индии)</a></span></li></ul></li><li><span class='b'><a href="2100">Азиатские сериалы</a></span><ul><li><span><a href="820">Азиатские сериалы (UHD Video)</a></span></li><li><span><a href="915">Корейские сериалы</a></span></li><li><span><a href="1242">Корейские сериалы (HD Video)</a></span></li><li><span><a href="717">Китайские сериалы</a></span></li><li><span><a href="1939">Японские сериалы</a></span></li><li><span><a href="2412">Сериалы Таиланда, Индонезии, Сингапура</a></span></li><li><span><a href="2102">VMV и др. ролики</a></span></li><li><span><a href="2101">Архив (Азиатские сериалы)</a></span></li></ul></li></ul></li></ul>
+<ul class='tree-root'><li><span class='b'><span class="c-title" title="Документалистика и юмор"></span></span><ul><li><span class='b'><a href="1629">Предложения по улучшению категории &quot;Документалистика и юмор&quot;</a></span></li><li><span class='b'><a href="19">СМИ</a></span></li><li><span class='b'><a href="670">Вера и религия</a></span><ul><li><span><a href="1475">[Видео Религия] Христианство</a></span></li><li><span><a href="2107">[Видео Религия] Ислам</a></span></li><li><span><a href="1453">[Видео Религия] Культы и новые религиозные движения</a></span></li><li><span><a href="294">[Видео Религия] Религии Индии, Тибета и Восточной Азии</a></span></li></ul></li><li><span class='b'><a href="46">Документальные фильмы и телепередачи</a></span><ul><li><span><a href="2172">-= Правила, инструкции, FAQ&#039;и =-</a></span></li><li><span><a href="73">Архив (Документальные фильмы)</a></span></li><li><span><a href="77">Ищу / Предлагаю / Анонсы ТВ</a></span></li><li><span><a href="103">Документальные (DVD)</a></span></li><li><span><a href="671">[Док] Биографии. Личности и кумиры</a></span></li><li><span><a href="2177">[Док] Кинематограф и мультипликация</a></span></li><li><span><a href="656">[Док] Мастера искусств Театра и Кино</a></span></li><li><span><a href="2538">[Док] Искусство, история искусств</a></span></li><li><span><a href="2159">[Док] Музыка</a></span></li><li><span><a href="251">[Док] Криминальная документалистика</a></span></li><li><span><a href="98">[Док] Тайны века / Спецслужбы / Теории Заговоров</a></span></li><li><span><a href="97">[Док] Военное дело</a></span></li><li><span><a href="851">[Док] Вторая мировая война</a></span></li><li><span><a href="2178">[Док] Аварии / Катастрофы / Катаклизмы</a></span></li><li><span><a href="821">[Док] Авиация</a></span></li><li><span><a href="2076">[Док] Космос</a></span></li><li><span><a href="56">[Док] Научно-популярные фильмы</a></span></li><li><span><a href="2123">[Док] Флора и фауна</a></span></li><li><span><a href="876">[Док] Путешествия и туризм</a></span></li><li><span><a href="2139">[Док] Медицина</a></span></li><li><span><a href="2380">[Док] Социальные ток-шоу</a></span></li><li><span><a href="1467">[Док] Информационно-аналитические и общественно-политические передачи</a></span></li><li><span><a href="1469">[Док] Архитектура и строительство</a></span></li><li><span><a href="672">[Док] Всё о доме, быте и дизайне</a></span></li><li><span><a href="249">[Док] BBC</a></span></li><li><span><a href="552">[Док] Discovery</a></span></li><li><span><a href="500">[Док] National Geographic</a></span></li><li><span><a href="2112">[Док] История: Древний мир / Античность / Средневековье</a></span></li><li><span><a href="1327">[Док] История: Новое и Новейшее время</a></span></li><li><span><a href="1468">[Док] Эпоха СССР</a></span></li><li><span><a href="1280">[Док] Битва экстрасенсов / Теория невероятности / Искатели / Галилео</a></span></li><li><span><a href="752">[Док] Русские сенсации / Программа Максимум / Профессия репортёр</a></span></li><li><span><a href="1114">[Док] Паранормальные явления</a></span></li><li><span><a href="2168">[Док] Альтернативная история и наука</a></span></li><li><span><a href="2160">[Док] Внежанровая документалистика</a></span></li><li><span><a href="2176">[Док] Разное / некондиция</a></span></li></ul></li><li><span class='b'><a href="314">Документальные (HD Video)</a></span><ul><li><span><a href="2323">Информационно-аналитические и общественно-политические (HD Video)</a></span></li><li><span><a href="1278">Биографии. Личности и кумиры (HD Video)</a></span></li><li><span><a href="1281">Военное дело (HD Video)</a></span></li><li><span><a href="2110">Естествознание, наука и техника (HD Video)</a></span></li><li><span><a href="979">Путешествия и туризм (HD Video)</a></span></li><li><span><a href="2169">Флора и фауна (HD Video)</a></span></li><li><span><a href="2166">История (HD Video)</a></span></li><li><span><a href="2164">BBC, Discovery, National Geographic, History Channel, Netflix (HD Video)</a></span></li><li><span><a href="2163">Криминальная документалистика (HD Video)</a></span></li><li><span><a href="85">Некондиционное видео - Документальные (HD Video)</a></span></li></ul></li><li><span class='b'><a href="24">Развлекательные телепередачи и шоу, приколы и юмор</a></span><ul><li><span><a href="891">Архив (Приколы и юмор)</a></span></li><li><span><a href="523">Ищу / предлагаю (Приколы и юмор)</a></span></li><li><span><a href="1959">[Видео Юмор] Интеллектуальные игры и викторины</a></span></li><li><span><a href="939">[Видео Юмор] Реалити и ток-шоу / номинации / показы</a></span></li><li><span><a href="1481">[Видео Юмор] Детские телешоу</a></span></li><li><span><a href="113">[Видео Юмор] КВН</a></span></li><li><span><a href="115">[Видео Юмор] Пост КВН</a></span></li><li><span><a href="882">[Видео Юмор] Кривое Зеркало / Городок / В Городке</a></span></li><li><span><a href="1482">[Видео Юмор] Ледовые шоу</a></span></li><li><span><a href="393">[Видео Юмор] Музыкальные шоу</a></span></li><li><span><a href="1569">[Видео Юмор] Званый ужин</a></span></li><li><span><a href="373">[Видео Юмор] Хорошие Шутки</a></span></li><li><span><a href="1186">[Видео Юмор] Вечерний Квартал</a></span></li><li><span><a href="137">[Видео Юмор] Фильмы со смешным переводом (пародии)</a></span></li><li><span><a href="2537">[Видео Юмор] Stand-up comedy</a></span></li><li><span><a href="532">[Видео Юмор] Украинские Шоу</a></span></li><li><span><a href="827">[Видео Юмор] Танцевальные шоу, концерты, выступления</a></span></li><li><span><a href="1484">[Видео Юмор] Цирк</a></span></li><li><span><a href="1485">[Видео Юмор] Школа злословия</a></span></li><li><span><a href="114">[Видео Юмор] Сатирики и юмористы</a></span></li><li><span><a href="1332">Юмористические аудиопередачи</a></span></li><li><span><a href="1495">Аудио и видео ролики (Приколы и юмор)</a></span></li></ul></li></ul></li></ul>
+<ul class='tree-root'><li><span class='b'><span class="c-title" title="Спорт"></span></span><ul><li><span class='b'><a href="926">XXV Зимние Олимпийские игры 2026</a></span><ul><li><span><a href="1311">Биатлон</a></span></li><li><span><a href="2171">Лыжные гонки</a></span></li><li><span><a href="2455">Горные лыжи. Сноубординг. Фристайл. Прыжки на лыжах с трамплина.Лыжное двоеборье</a></span></li><li><span><a href="1434">Конькобежный спорт. Шорт-трек. Бобслей. Санный спорт. Скелетон</a></span></li><li><span><a href="1339">Фигурное катание</a></span></li><li><span><a href="922">Хоккей</a></span></li><li><span><a href="918">Керлинг</a></span></li></ul></li><li><span class='b'><a href="1315">XXIV Зимние Олимпийские игры 2022</a></span><ul><li><span><a href="1336">Биатлон.Лыжные гонки.Прыжки с трамп.Двоеборье.Горные лыжи.Сноубординг.Фристайл</a></span></li><li><span><a href="2350">Конькобежный спорт. Шорт-трек. Бобслей. Санный спорт. Скелетон</a></span></li><li><span><a href="1472">Фигурное катание</a></span></li><li><span><a href="2068">Хоккей</a></span></li><li><span><a href="2016">Керлинг</a></span></li></ul></li><li><span class='b'><a href="1346">XXXIII Летние Олимпийские игры 2024</a></span><ul><li><span><a href="2493">Легкая атлетика. Плавание. Прыжки в воду. Синхронное плавание. Гимнастика</a></span></li><li><span><a href="2103">Велоспорт. Академическая гребля. Гребля на байдарках и каноэ</a></span></li><li><span><a href="2485">Футбол. Баскетбол. Волейбол. Гандбол. Водное поло. Регби. Хоккей на траве</a></span></li><li><span><a href="2479">Теннис. Настольный теннис. Бадминтон</a></span></li><li><span><a href="2089">Фехтование. Стрельба. Стрельба из лука. Современное пятиборье</a></span></li><li><span><a href="2338">Бокс. Борьба Вольная и Греко-римская. Дзюдо. Карате. Тхэквондо</a></span></li><li><span><a href="927">Другие виды спорта</a></span></li></ul></li><li><span class='b'><a href="1392">XXXII Летние Олимпийские игры 2020</a></span><ul><li><span><a href="2475">Легкая атлетика. Плавание. Прыжки в воду. Синхронное плавание</a></span></li><li><span><a href="2113">Гимнастика. Прыжки на батуте. Фехтование. Стрельба. Современное пятиборье</a></span></li><li><span><a href="2482">Велоспорт. Академическая гребля. Гребля на байдарках и каноэ</a></span></li><li><span><a href="2522">Бокс. Борьба Вольная и Греко-римская. Дзюдо. Карате. Тхэквондо</a></span></li><li><span><a href="2486">Футбол. Баскетбол. Волейбол. Гандбол. Водное поло. Регби. Хоккей на траве</a></span></li><li><span><a href="1794">Другие виды спорта</a></span></li></ul></li><li><span class='b'><a href="255">Спортивные турниры, фильмы и передачи</a></span><ul><li><span><a href="261">Архив (Спорт)</a></span></li><li><span><a href="964">Архив 2 (Спорт)</a></span></li><li><span><a href="256">Автоспорт</a></span></li><li><span><a href="1986">Мотоспорт</a></span></li><li><span><a href="660">Формула-1 (2026)</a></span></li><li><span><a href="1551">Формула-1 (2012-2025)</a></span></li><li><span><a href="626">Формула 1 (до 2011 вкл.)</a></span></li><li><span><a href="262">Велоспорт</a></span></li><li><span><a href="1326">Волейбол/Гандбол</a></span></li><li><span><a href="978">Бильярд</a></span></li><li><span><a href="1287">Покер</a></span></li><li><span><a href="1188">Бодибилдинг/Силовые виды спорта</a></span></li><li><span><a href="1667">Бокс</a></span></li><li><span><a href="1675">Классические единоборства</a></span></li><li><span><a href="257">Смешанные единоборства и K-1</a></span></li><li><span><a href="875">Американский футбол</a></span></li><li><span><a href="263">Регби</a></span></li><li><span><a href="2073">Бейсбол</a></span></li><li><span><a href="550">Теннис</a></span></li><li><span><a href="2124">Бадминтон/Настольный теннис</a></span></li><li><span><a href="1470">Гимнастика/Соревнования по танцам</a></span></li><li><span><a href="528">Лёгкая атлетика/Водные виды спорта</a></span></li><li><span><a href="486">Зимние виды спорта</a></span></li><li><span><a href="854">Фигурное катание</a></span></li><li><span><a href="2079">Биатлон</a></span></li><li><span><a href="260">Экстрим</a></span></li><li><span><a href="1319">Спорт (видео)</a></span></li></ul></li><li><span class='b'><a href="1608">&#9917; Футбол</a></span><ul><li><span><a href="2294">UHDTV</a></span></li><li><span><a href="2545">Клубный Чемпионат Мира 2025</a></span></li><li><span><a href="2147">Чемпионат Мира 2026 (финальный турнир)</a></span></li><li><span><a href="1693">Чемпионат Мира 2026 (отбор)</a></span></li><li><span><a href="136">Чемпионат Европы 2024 (финальный турнир)</a></span></li><li><span><a href="2532">Чемпионат Европы 2020 [2021] (финальный турнир)</a></span></li><li><span><a href="592">Лига Наций</a></span></li><li><span><a href="1229">Чемпионат Мира 2022</a></span></li><li><span><a href="2533">Чемпионат Мира 2018 (игры)</a></span></li><li><span><a href="1952">Чемпионат Мира 2018 (обзорные передачи, документалистика)</a></span></li><li><span><a href="1621">Чемпионаты Мира</a></span></li><li><span><a href="1668">Россия 2025-2026</a></span></li><li><span><a href="2075">Россия 2024-2025</a></span></li><li><span><a href="1613">Россия/СССР</a></span></li><li><span><a href="1614">Англия</a></span></li><li><span><a href="1623">Испания</a></span></li><li><span><a href="1615">Италия</a></span></li><li><span><a href="1630">Германия</a></span></li><li><span><a href="2425">Франция</a></span></li><li><span><a href="2514">Украина</a></span></li><li><span><a href="1616">Другие национальные чемпионаты и кубки</a></span></li><li><span><a href="2014">Международные турниры</a></span></li><li><span><a href="1491">Еврокубки 2025-2026</a></span></li><li><span><a href="1442">Еврокубки 2024-2025</a></span></li><li><span><a href="1987">Еврокубки 2011-2024</a></span></li><li><span><a href="1617">Еврокубки</a></span></li><li><span><a href="1620">Чемпионаты Европы</a></span></li><li><span><a href="1998">Товарищеские турниры и матчи</a></span></li><li><span><a href="1343">Обзорные и аналитические передачи 2018-2025</a></span></li><li><span><a href="751">Обзорные и аналитические передачи</a></span></li><li><span><a href="497">Документальные фильмы (футбол)</a></span></li><li><span><a href="1697">Мини-футбол/Пляжный футбол</a></span></li><li><span><a href="1609">Архив (Футбол)</a></span></li><li><span><a href="1610">Архив (Футбол) резервный</a></span></li></ul></li><li><span class='b'><a href="2004">&#127936; Баскетбол</a></span><ul><li><span><a href="1999">Архив (Баскетбол)</a></span></li><li><span><a href="2001">Международные соревнования</a></span></li><li><span><a href="2002">NBA / NCAA (до 2000 г.)</a></span></li><li><span><a href="283">NBA / NCAA (2000-2010 гг.)</a></span></li><li><span><a href="1997">NBA / NCAA (2010-2026 гг.)</a></span></li><li><span><a href="2003">Европейский клубный баскетбол</a></span></li></ul></li><li><span class='b'><a href="2009">&#127954; Хоккей</a></span><ul><li><span><a href="2000">Архив (Хоккей)</a></span></li><li><span><a href="2010">Хоккей с мячом / Бенди</a></span></li><li><span><a href="2006">Международные турниры</a></span></li><li><span><a href="2007">КХЛ</a></span></li><li><span><a href="2005">НХЛ (до 2011/12)</a></span></li><li><span><a href="259">НХЛ (с 2013)</a></span></li><li><span><a href="2008">СССР - Канада</a></span></li><li><span><a href="126">Документальные фильмы и аналитика</a></span></li></ul></li><li><span class='b'><a href="845">Рестлинг</a></span><ul><li><span><a href="1476">Общение (Рестлинг)</a></span></li><li><span><a href="343">Professional Wrestling</a></span></li><li><span><a href="2111">Independent Wrestling</a></span></li><li><span><a href="1527">International Wrestling</a></span></li><li><span><a href="2069">Oldschool Wrestling</a></span></li><li><span><a href="1323">Documentary Wrestling</a></span></li><li><span><a href="2312">Архив (Рестлинг)</a></span></li></ul></li></ul></li></ul>
+<ul class='tree-root'><li><span class='b'><span class="c-title" title="Книги и журналы"></span></span><ul><li><span class='b'><a href="2058">Правила &quot;Книг и журналов&quot;, помощь, предложения по улучшению, сканирование</a></span><ul><li><span><a href="1411">Сканирование, обработка сканов</a></span></li></ul></li><li><span class='b'><a href="21">Книги и журналы (общий раздел)</a></span><ul><li><span><a href="2157">Кино, театр, ТВ, мультипликация, цирк</a></span></li><li><span><a href="765">Рисунок, графический дизайн</a></span></li><li><span><a href="2019">Фото и видеосъемка</a></span></li><li><span><a href="31">Журналы и газеты (общий раздел)</a></span></li><li><span><a href="1427">Эзотерика, гадания, магия, фен-шуй</a></span></li><li><span><a href="2422">Астрология</a></span></li><li><span><a href="2195">Красота. Уход. Домоводство</a></span></li><li><span><a href="2521">Мода. Стиль. Этикет</a></span></li><li><span><a href="2223">Путешествия и туризм</a></span></li><li><span><a href="2447">Знаменитости и кумиры</a></span></li><li><span><a href="39">Разное (книги)</a></span></li><li><span><a href="2086">Самиздат, статьи из журналов, фрагменты книг, любительские переводы</a></span></li></ul></li><li><span class='b'><a href="1101">Для детей, родителей и учителей</a></span><ul><li><span><a href="745">Учебная литература для детского сада и начальной школы (до 4 класса)</a></span></li><li><span><a href="1689">Учебная литература для старших классов (5-11 класс)</a></span></li><li><span><a href="2336">Учителям и педагогам</a></span></li><li><span><a href="2337">Научно-популярная и познавательная литература (для детей)</a></span></li><li><span><a href="1353">Досуг и творчество</a></span></li><li><span><a href="1400">Воспитание и развитие</a></span></li><li><span><a href="1415">Худ. лит-ра для дошкольников и младших классов</a></span></li><li><span><a href="2046">Худ. лит-ра для средних и старших классов</a></span></li></ul></li><li><span class='b'><a href="1802">Спорт, физическая культура, боевые искусства</a></span><ul><li><span><a href="2189">Футбол (книги и журналы)</a></span></li><li><span><a href="2190">Хоккей (книги и журналы)</a></span></li><li><span><a href="2443">Игровые виды спорта</a></span></li><li><span><a href="1477">Легкая атлетика. Плавание. Гимнастика. Тяжелая атлетика. Гребля</a></span></li><li><span><a href="669">Автоспорт. Мотоспорт. Велоспорт</a></span></li><li><span><a href="2196">Шахматы. Шашки</a></span></li><li><span><a href="2056">Боевые искусства, единоборства</a></span></li><li><span><a href="1436">Экстрим (книги)</a></span></li><li><span><a href="2191">Физкультура, фитнес, бодибилдинг</a></span></li><li><span><a href="2477">Спортивная пресса</a></span></li></ul></li><li><span class='b'><a href="1680">Гуманитарные науки</a></span><ul><li><span><a href="1684">Искусствоведение. Культурология</a></span></li><li><span><a href="2446">Фольклор. Эпос. Мифология</a></span></li><li><span><a href="2524">Литературоведение</a></span></li><li><span><a href="2525">Лингвистика</a></span></li><li><span><a href="995">Философия</a></span></li><li><span><a href="2022">Политология</a></span></li><li><span><a href="2471">Социология</a></span></li><li><span><a href="2375">Публицистика, журналистика</a></span></li><li><span><a href="764">Бизнес, менеджмент</a></span></li><li><span><a href="1685">Маркетинг</a></span></li><li><span><a href="1688">Экономика</a></span></li><li><span><a href="2472">Финансы</a></span></li><li><span><a href="1687">Юридические науки. Право. Криминалистика</a></span></li></ul></li><li><span class='b'><a href="2020">Исторические науки</a></span><ul><li><span><a href="1349">Методология и философия исторической науки</a></span></li><li><span><a href="1967">Исторические источники (книги, периодика)</a></span></li><li><span><a href="1341">Исторические источники (документы)</a></span></li><li><span><a href="2049">Исторические персоны</a></span></li><li><span><a href="1681">Альтернативные исторические теории</a></span></li><li><span><a href="2319">Археология</a></span></li><li><span><a href="2434">Древний мир. Античность</a></span></li><li><span><a href="1683">Средние века</a></span></li><li><span><a href="2444">История Нового и Новейшего времени</a></span></li><li><span><a href="2427">История Европы</a></span></li><li><span><a href="2452">История Азии и Африки</a></span></li><li><span><a href="2445">История Америки, Австралии, Океании</a></span></li><li><span><a href="2435">История России</a></span></li><li><span><a href="667">История России до 1917 года</a></span></li><li><span><a href="2436">Эпоха СССР</a></span></li><li><span><a href="1335">История России после 1991 года</a></span></li><li><span><a href="2453">История стран бывшего СССР</a></span></li><li><span><a href="2320">Этнография, антропология</a></span></li><li><span><a href="1801">Международные отношения. Дипломатия</a></span></li></ul></li><li><span class='b'><a href="2023">Точные, естественные и инженерные науки</a></span><ul><li><span><a href="2024">Авиация / Космонавтика</a></span></li><li><span><a href="2026">Физика</a></span></li><li><span><a href="2192">Астрономия</a></span></li><li><span><a href="2027">Биология / Экология</a></span></li><li><span><a href="295">Химия / Биохимия</a></span></li><li><span><a href="2028">Математика</a></span></li><li><span><a href="2029">География / Геология / Геодезия</a></span></li><li><span><a href="1325">Электроника / Радио</a></span></li><li><span><a href="2386">Схемы и сервис-мануалы (оригинальная документация)</a></span></li><li><span><a href="2031">Архитектура / Строительство / Инженерные сети / Ландшафтный дизайн</a></span></li><li><span><a href="2030">Машиностроение</a></span></li><li><span><a href="2526">Сварка / Пайка / Неразрушающий контроль</a></span></li><li><span><a href="2527">Автоматизация / Робототехника</a></span></li><li><span><a href="2254">Металлургия / Материаловедение</a></span></li><li><span><a href="2376">Механика, сопротивление материалов</a></span></li><li><span><a href="2054">Энергетика / электротехника</a></span></li><li><span><a href="770">Нефтяная, газовая и химическая промышленность</a></span></li><li><span><a href="2476">Сельское хозяйство и пищевая промышленность</a></span></li><li><span><a href="2494">Железнодорожное дело</a></span></li><li><span><a href="1528">Нормативная документация</a></span></li><li><span><a href="2032">Журналы: научные, научно-популярные, радио и др.</a></span></li></ul></li><li><span class='b'><a href="919">Ноты и Музыкальная литература</a></span><ul><li><span><a href="947">Архив (Ноты и Музыкальная литература)</a></span></li><li><span><a href="945">Поиск и обсуждение (Ноты и Музыкальная литература)</a></span></li><li><span><a href="944">Академическая музыка (Ноты и Media CD)</a></span></li><li><span><a href="980">Другие направления (Ноты, табулатуры)</a></span></li><li><span><a href="946">Самоучители и Школы</a></span></li><li><span><a href="977">Песенники (Songbooks)</a></span></li><li><span><a href="2074">Музыкальная литература и Теория</a></span></li><li><span><a href="2349">Музыкальные журналы</a></span></li></ul></li><li><span class='b'><a href="768">Военное дело</a></span><ul><li><span><a href="2099">Милитария</a></span></li><li><span><a href="2021">Военная история</a></span></li><li><span><a href="2437">История Второй мировой войны</a></span></li><li><span><a href="1337">Биографии и мемуары военных деятелей</a></span></li><li><span><a href="1447">Военная техника</a></span></li><li><span><a href="2468">Стрелковое оружие</a></span></li><li><span><a href="2469">Учебно-методическая литература</a></span></li><li><span><a href="2470">Спецслужбы мира</a></span></li></ul></li><li><span class='b'><a href="1686">Вера и религия</a></span><ul><li><span><a href="2215">Христианство</a></span></li><li><span><a href="2216">Ислам</a></span></li><li><span><a href="2546">Иудаизм</a></span></li><li><span><a href="2217">Религии Индии, Тибета и Восточной Азии</a></span></li><li><span><a href="2218">Нетрадиционные религиозные, духовные и мистические учения</a></span></li><li><span><a href="2252">Религиоведение. История Религии</a></span></li><li><span><a href="2543">Атеизм. Научный атеизм</a></span></li></ul></li><li><span class='b'><a href="767">Психология</a></span><ul><li><span><a href="2515">Общая и прикладная психология</a></span></li><li><span><a href="2516">Психотерапия и консультирование</a></span></li><li><span><a href="2517">Психодиагностика и психокоррекция</a></span></li><li><span><a href="2518">Социальная психология и психология отношений</a></span></li><li><span><a href="2519">Тренинг и коучинг</a></span></li><li><span><a href="2520">Саморазвитие и самосовершенствование</a></span></li><li><span><a href="1696">Популярная психология</a></span></li><li><span><a href="2253">Сексология. Взаимоотношения полов (18+)</a></span></li></ul></li><li><span class='b'><a href="2033">Коллекционирование, увлечения и хобби</a></span><ul><li><span><a href="1412">Коллекционирование и вспомогательные ист. дисциплины</a></span></li><li><span><a href="1446">Вышивание</a></span></li><li><span><a href="753">Вязание</a></span></li><li><span><a href="2037">Шитье, пэчворк</a></span></li><li><span><a href="2224">Кружевоплетение</a></span></li><li><span><a href="2194">Бисероплетение. Ювелирика. Украшения из проволоки</a></span></li><li><span><a href="2418">Бумажный арт</a></span></li><li><span><a href="1410">Другие виды декоративно-прикладного искусства</a></span></li><li><span><a href="2034">Домашние питомцы и аквариумистика</a></span></li><li><span><a href="2433">Охота и рыбалка</a></span></li><li><span><a href="1961">Кулинария (книги)</a></span></li><li><span><a href="2432">Кулинария (газеты и журналы)</a></span></li><li><span><a href="565">Моделизм</a></span></li><li><span><a href="1523">Приусадебное хозяйство / Цветоводство</a></span></li><li><span><a href="1575">Ремонт, частное строительство, дизайн интерьеров</a></span></li><li><span><a href="1520">Деревообработка</a></span></li><li><span><a href="2424">Настольные игры</a></span></li><li><span><a href="769">Прочие хобби и игры</a></span></li></ul></li><li><span class='b'><a href="2038">Художественная литература</a></span><ul><li><span><a href="2043">Русская литература</a></span></li><li><span><a href="2042">Зарубежная литература (до 1900 г.)</a></span></li><li><span><a href="2041">Зарубежная литература (XX и XXI век)</a></span></li><li><span><a href="2044">Детектив, боевик</a></span></li><li><span><a href="2039">Женский роман</a></span></li><li><span><a href="2045">Отечественная фантастика / фэнтези / мистика</a></span></li><li><span><a href="2080">Зарубежная фантастика / фэнтези / мистика</a></span></li><li><span><a href="2047">Приключения</a></span></li><li><span><a href="2193">Литературные журналы</a></span></li><li><span><a href="1037">Самиздат и книги, изданные за счет авторов</a></span></li></ul></li><li><span class='b'><a href="1418">Компьютерная литература</a></span><ul><li><span><a href="1422">Программы от Microsoft</a></span></li><li><span><a href="1423">Другие программы</a></span></li><li><span><a href="1424">Mac OS; Linux, FreeBSD и прочие *NIX</a></span></li><li><span><a href="1445">СУБД</a></span></li><li><span><a href="1425">Веб-дизайн и программирование</a></span></li><li><span><a href="1426">Программирование (книги)</a></span></li><li><span><a href="1428">Графика, обработка видео</a></span></li><li><span><a href="1429">Сети / VoIP</a></span></li><li><span><a href="1430">Хакинг и безопасность</a></span></li><li><span><a href="1431">Железо (книги о ПК)</a></span></li><li><span><a href="1433">Инженерные и научные программы (книги)</a></span></li><li><span><a href="1432">Компьютерные журналы и приложения к ним</a></span></li><li><span><a href="2202">Дисковые приложения к игровым журналам</a></span></li></ul></li><li><span class='b'><a href="862">Комиксы, манга, ранобэ</a></span><ul><li><span><a href="2461">Комиксы на русском языке</a></span></li><li><span><a href="2462">Комиксы издательства Marvel</a></span></li><li><span><a href="2463">Комиксы издательства DC</a></span></li><li><span><a href="2464">Комиксы других издательств</a></span></li><li><span><a href="2473">Комиксы на других языках</a></span></li><li><span><a href="281">Манга (на русском языке)</a></span></li><li><span><a href="2465">Манга (на иностранных языках)</a></span></li><li><span><a href="2458">Ранобэ</a></span></li></ul></li><li><span class='b'><a href="2048">Коллекции книг и библиотеки</a></span><ul><li><span><a href="1238">Библиотеки (зеркала сетевых библиотек/коллекций)</a></span></li><li><span><a href="2055">Тематические коллекции (подборки)</a></span></li><li><span><a href="754">Многопредметные коллекции (подборки)</a></span></li></ul></li><li><span class='b'><a href="2114">Мультимедийные и интерактивные издания</a></span><ul><li><span><a href="2438">Мультимедийные энциклопедии</a></span></li><li><span><a href="2439">Интерактивные обучающие и развивающие материалы</a></span></li><li><span><a href="2440">Обучающие издания для детей</a></span></li><li><span><a href="2441">Кулинария. Цветоводство. Домоводство</a></span></li><li><span><a href="2442">Культура. Искусство. История</a></span></li></ul></li><li><span class='b'><a href="2125">Медицина и здоровье</a></span><ul><li><span><a href="2133">Клиническая медицина до 1980 года</a></span></li><li><span><a href="2130">Клиническая медицина с 1980 по 2000 год</a></span></li><li><span><a href="2313">Клиническая медицина после 2000 года</a></span></li><li><span><a href="2528">Научная медицинская периодика (газеты и журналы)</a></span></li><li><span><a href="2129">Медико-биологические науки</a></span></li><li><span><a href="2141">Фармация и фармакология</a></span></li><li><span><a href="2314">Популярная медицинская периодика (газеты и журналы)</a></span></li><li><span><a href="2132">Нетрадиционная, народная медицина и популярные книги о здоровье</a></span></li><li><span><a href="2131">Ветеринария, разное</a></span></li></ul></li><li><span class='b'><a href="71">Архив (Книги и журналы)</a></span></li></ul></li></ul>
+<ul class='tree-root'><li><span class='b'><span class="c-title" title="Обучение иностранным языкам"></span></span><ul><li><span class='b'><a href="2354">Объявления, предложения, помощь по разделу</a></span></li><li><span class='b'><a href="2362">Иностранные языки для взрослых</a></span><ul><li><span><a href="1265">Английский язык (для взрослых)</a></span></li><li><span><a href="1266">Немецкий язык</a></span></li><li><span><a href="1267">Французский язык</a></span></li><li><span><a href="1358">Испанский язык</a></span></li><li><span><a href="2363">Итальянский язык</a></span></li><li><span><a href="734">Финский язык</a></span></li><li><span><a href="1268">Другие европейские языки</a></span></li><li><span><a href="1673">Арабский язык</a></span></li><li><span><a href="1269">Китайский язык</a></span></li><li><span><a href="1270">Японский язык</a></span></li><li><span><a href="1275">Другие восточные языки</a></span></li><li><span><a href="2364">Русский язык как иностранный</a></span></li><li><span><a href="1276">Мультиязычные сборники и курсы</a></span></li><li><span><a href="2094">LIM-курсы</a></span></li><li><span><a href="1274">Разное (иностранные языки)</a></span></li></ul></li><li><span class='b'><a href="1264">Иностранные языки для детей</a></span><ul><li><span><a href="2358">Английский язык (для детей)</a></span></li><li><span><a href="2359">Другие европейские языки (для детей)</a></span></li><li><span><a href="2360">Восточные языки (для детей)</a></span></li><li><span><a href="2361">Школьные учебники, ЕГЭ, ОГЭ</a></span></li></ul></li><li><span class='b'><a href="2057">Художественная литература (ин.языки)</a></span><ul><li><span><a href="2355">Художественная литература на английском языке</a></span></li><li><span><a href="2474">Художественная литература на французском языке</a></span></li><li><span><a href="2356">Художественная литература на других европейских языках</a></span></li><li><span><a href="2357">Художественная литература на восточных языках</a></span></li></ul></li><li><span class='b'><a href="2413">Аудиокниги на иностранных языках</a></span><ul><li><span><a href="1501">Аудиокниги на английском языке</a></span></li><li><span><a href="1580">Аудиокниги на немецком языке</a></span></li><li><span><a href="525">Аудиокниги на других иностранных языках</a></span></li></ul></li><li><span class='b'><a href="1271">Архив (Иностранные языки)</a></span></li></ul></li></ul>
+<ul class='tree-root'><li><span class='b'><span class="c-title" title="Обучающие видео"></span></span><ul><li><span class='b'><a href="610">Видеоуроки и обучающие интерактивные DVD</a></span><ul><li><span><a href="628">Архив (Видеоуроки)</a></span></li><li><span><a href="1568">Кулинария</a></span></li><li><span><a href="1542">Спорт</a></span></li><li><span><a href="2335">Фитнес - Кардио-Силовые Тренировки</a></span></li><li><span><a href="1544">Фитнес - Разум и Тело</a></span></li><li><span><a href="1546">Бодибилдинг</a></span></li><li><span><a href="1549">Оздоровительные практики</a></span></li><li><span><a href="1597">Йога</a></span></li><li><span><a href="1552">Видео- и фотосъёмка</a></span></li><li><span><a href="1550">Уход за собой</a></span></li><li><span><a href="1553">Рисование</a></span></li><li><span><a href="1554">Игра на гитаре</a></span></li><li><span><a href="617">Ударные инструменты</a></span></li><li><span><a href="1555">Другие музыкальные инструменты</a></span></li><li><span><a href="2017">Игра на бас-гитаре</a></span></li><li><span><a href="1257">Бальные танцы</a></span></li><li><span><a href="1258">Танец живота</a></span></li><li><span><a href="2208">Уличные и клубные танцы</a></span></li><li><span><a href="677">Танцы, разное</a></span></li><li><span><a href="1255">Охота</a></span></li><li><span><a href="1479">Рыболовство и подводная охота</a></span></li><li><span><a href="1261">Фокусы и трюки</a></span></li><li><span><a href="614">Образование</a></span></li><li><span><a href="1583">Финансы</a></span></li><li><span><a href="1259">Продажи, бизнес</a></span></li><li><span><a href="2065">Беременность, роды, материнство</a></span></li><li><span><a href="1254">Учебные видео для детей</a></span></li><li><span><a href="1260">Психология</a></span></li><li><span><a href="2209">Эзотерика, саморазвитие</a></span></li><li><span><a href="2210">Пикап, знакомства</a></span></li><li><span><a href="1547">Строительство, ремонт и дизайн</a></span></li><li><span><a href="1548">Дерево- и металлообработка</a></span></li><li><span><a href="2211">Растения и животные</a></span></li><li><span><a href="1596">Хобби и рукоделие</a></span></li><li><span><a href="2135">Медицина и стоматология</a></span></li><li><span><a href="2140">Психотерапия и клиническая психология</a></span></li><li><span><a href="2136">Массаж</a></span></li><li><span><a href="2138">Здоровье</a></span></li><li><span><a href="615">Разное</a></span></li></ul></li><li><span class='b'><a href="1581">Боевые искусства (Видеоуроки)</a></span><ul><li><span><a href="1582">Архив (Боевые искусства)</a></span></li><li><span><a href="1590">Айкидо и айки-дзюцу</a></span></li><li><span><a href="1587">Вин чун</a></span></li><li><span><a href="1594">Джиу-джитсу</a></span></li><li><span><a href="1591">Дзюдо и самбо</a></span></li><li><span><a href="1588">Каратэ</a></span></li><li><span><a href="1585">Работа с оружием</a></span></li><li><span><a href="1586">Русский стиль</a></span></li><li><span><a href="2078">Рукопашный бой</a></span></li><li><span><a href="1929">Смешанные стили</a></span></li><li><span><a href="1593">Ударные стили</a></span></li><li><span><a href="1592">Ушу</a></span></li><li><span><a href="1595">Разное</a></span></li></ul></li><li><span class='b'><a href="1556">Компьютерные видеоуроки и обучающие интерактивные DVD</a></span><ul><li><span><a href="1557">Архив (Компьютерные видеоуроки)</a></span></li><li><span><a href="2539">Machine/Deep Learning, Neural Networks</a></span></li><li><span><a href="1560">Компьютерные сети и безопасность</a></span></li><li><span><a href="1991">Devops</a></span></li><li><span><a href="1561">ОС и серверные программы Microsoft</a></span></li><li><span><a href="1653">Офисные программы Microsoft</a></span></li><li><span><a href="1570">ОС и программы семейства UNIX</a></span></li><li><span><a href="1654">Adobe Photoshop</a></span></li><li><span><a href="1655">Autodesk Maya</a></span></li><li><span><a href="1656">Autodesk 3ds Max</a></span></li><li><span><a href="1930">Autodesk Softimage (XSI)</a></span></li><li><span><a href="1931">ZBrush</a></span></li><li><span><a href="1932">Flash, Flex и ActionScript</a></span></li><li><span><a href="1562">2D-графика</a></span></li><li><span><a href="1563">3D-графика</a></span></li><li><span><a href="1626">Инженерные и научные программы (видеоуроки)</a></span></li><li><span><a href="1564">Web-дизайн</a></span></li><li><span><a href="1545">WEB, SMM, SEO, интернет-маркетинг</a></span></li><li><span><a href="1565">Программирование (видеоуроки)</a></span></li><li><span><a href="1559">Программы для Mac OS</a></span></li><li><span><a href="1566">Работа с видео</a></span></li><li><span><a href="1573">Работа со звуком</a></span></li><li><span><a href="1567">Разное (Компьютерные видеоуроки)</a></span></li></ul></li></ul></li></ul>
+<ul class='tree-root'><li><span class='b'><span class="c-title" title="Аудиокниги"></span></span><ul><li><span class='b'><a href="395">Новости, объявления, полезная информация</a></span><ul><li><span><a href="396">Архив (Аудиокниги)</a></span></li><li><span><a href="2322">Общение, обсуждения, поиск аудиокниг</a></span></li><li><span><a href="2167">Авторы</a></span></li><li><span><a href="1993">Исполнители</a></span></li><li><span><a href="2321">Предложения по улучшению категории &quot;Аудиокниги&quot;</a></span></li></ul></li><li><span class='b'><a href="2326">Радиоспектакли, история, мемуары</a></span><ul><li><span><a href="574">[Аудио] Радиоспектакли и литературные чтения</a></span></li><li><span><a href="1036">[Аудио] Биографии и мемуары</a></span></li><li><span><a href="400">[Аудио] История, культурология, философия</a></span></li></ul></li><li><span class='b'><a href="2389">Фантастика, фэнтези, мистика, ужасы, фанфики</a></span><ul><li><span><a href="2388">[Аудио] Зарубежная фантастика, фэнтези, мистика, ужасы, фанфики</a></span></li><li><span><a href="2387">[Аудио] Российская фантастика, фэнтези, мистика, ужасы, фанфики</a></span></li><li><span><a href="661">[Аудио] Любовно-фантастический роман</a></span></li><li><span><a href="2348">[Аудио] Сборники/разное Фантастика, фэнтези, мистика, ужасы, фанфики</a></span></li></ul></li><li><span class='b'><a href="2327">Художественная литература</a></span><ul><li><span><a href="695">[Аудио] Поэзия</a></span></li><li><span><a href="399">[Аудио] Зарубежная литература</a></span></li><li><span><a href="402">[Аудио] Русская литература</a></span></li><li><span><a href="467">[Аудио] Современные любовные романы</a></span></li><li><span><a href="490">[Аудио] Детская литература</a></span></li><li><span><a href="499">[Аудио] Зарубежные детективы, приключения, триллеры, боевики</a></span></li><li><span><a href="2137">[Аудио] Российские детективы, приключения, триллеры, боевики</a></span></li><li><span><a href="2127">[Аудио] Азиатская подростковая литература, ранобэ, веб-новеллы</a></span></li></ul></li><li><span class='b'><a href="2324">Религии</a></span><ul><li><span><a href="2325">[Аудио] Православие</a></span></li><li><span><a href="2342">[Аудио] Ислам</a></span></li><li><span><a href="530">[Аудио] Другие традиционные религии</a></span></li><li><span><a href="2152">[Аудио] Нетрадиционные религиозно-философские учения</a></span></li></ul></li><li><span class='b'><a href="2328">Прочая литература</a></span><ul><li><span><a href="1350">[Аудио] Книги по медицине</a></span></li><li><span><a href="403">[Аудио] Учебная и научно-популярная литература</a></span></li><li><span><a href="1279">[Аудио] lossless-аудиокниги</a></span></li><li><span><a href="716">[Аудио] Бизнес</a></span></li><li><span><a href="2165">[Аудио] Разное</a></span></li><li><span><a href="401">[Аудио] Некондиционные раздачи</a></span></li></ul></li></ul></li></ul>
+<ul class='tree-root'><li><span class='b'><span class="c-title" title="Авто и мото"></span></span><ul><li><span class='b'><a href="1964">Ремонт и эксплуатация транспортных средств</a></span><ul><li><span><a href="1966">Архив (Авто и мото)</a></span></li><li><span><a href="1968">Ищу / Предлагаю (Ремонт и эксплуатация ТС)</a></span></li><li><span><a href="1972">Общение</a></span></li><li><span><a href="1973">Оригинальные каталоги по подбору запчастей</a></span></li><li><span><a href="1974">Неоригинальные каталоги по подбору запчастей</a></span></li><li><span><a href="1975">Программы по диагностике и ремонту</a></span></li><li><span><a href="1976">Тюнинг, чиптюнинг, настройка</a></span></li><li><span><a href="1977">Книги по ремонту/обслуживанию/эксплуатации ТС</a></span></li><li><span><a href="1203">Мультимедийки по ремонту/обслуживанию/эксплуатации ТС</a></span></li><li><span><a href="1978">Учет, утилиты и прочее</a></span></li><li><span><a href="1979">Виртуальная автошкола</a></span></li><li><span><a href="1980">Видеоуроки по вождению транспортных средств</a></span></li><li><span><a href="1981">Видеоуроки по ремонту транспортных средств</a></span></li><li><span><a href="1970">Журналы по авто/мото</a></span></li><li><span><a href="334">Водный транспорт</a></span></li></ul></li><li><span class='b'><a href="1202">Фильмы и передачи по авто/мото</a></span><ul><li><span><a href="1985">Документальные/познавательные фильмы</a></span></li><li><span><a href="1982">Развлекательные передачи</a></span></li><li><span><a href="2151">Top Gear/Топ Гир</a></span></li><li><span><a href="1983">Тест драйв/Обзоры/Автосалоны</a></span></li><li><span><a href="1984">Тюнинг/форсаж</a></span></li></ul></li></ul></li></ul>
+<ul class='tree-root'><li><span class='b'><span class="c-title" title="Музыка"></span></span><ul><li><span class='b'><a href="757">Предложения по улучшению музыкальных разделов</a></span></li><li><span class='b'><a href="215">Помощь по музыкальным разделам</a></span><ul><li><span><a href="1872">Инструкции, руководства, обзоры</a></span></li><li><span><a href="675">Вопросы и ответы по музыкальным разделам</a></span></li><li><span><a href="1874">Поиск музыки</a></span></li></ul></li><li><span class='b'><a href="409">Классическая и современная академическая музыка</a></span><ul><li><span><a href="792">Каталоги раздач классической и академической музыки</a></span></li><li><span><a href="435">Классическая музыка (обсуждение)</a></span></li><li><span><a href="443">Архив (Классическая музыка)</a></span></li><li><span><a href="560">Полные собрания сочинений и многодисковые издания (lossless)</a></span></li><li><span><a href="794">Опера (lossless)</a></span></li><li><span><a href="556">Вокальная музыка (lossless)</a></span></li><li><span><a href="2307">Хоровая музыка (lossless)</a></span></li><li><span><a href="557">Оркестровая музыка (lossless)</a></span></li><li><span><a href="2308">Концерт для инструмента с оркестром (lossless)</a></span></li><li><span><a href="558">Камерная инструментальная музыка (lossless)</a></span></li><li><span><a href="793">Сольная инструментальная музыка (lossless)</a></span></li><li><span><a href="1395">Духовные песнопения и музыка (lossless)</a></span></li><li><span><a href="1396">Духовные песнопения и музыка (lossy)</a></span></li><li><span><a href="436">Полные собрания сочинений и многодисковые издания (lossy)</a></span></li><li><span><a href="2309">Вокальная и хоровая музыка (lossy)</a></span></li><li><span><a href="2310">Оркестровая музыка (lossy)</a></span></li><li><span><a href="2311">Камерная и сольная инструментальная музыка (lossy)</a></span></li><li><span><a href="969">Классика в современной обработке, Classical Crossover (lossy и lossless)</a></span></li></ul></li><li><span class='b'><a href="1125">Фольклор, Народная и Этническая музыка</a></span><ul><li><span><a href="1140">Архив (Фольклор, Народная и Этническая музыка)</a></span></li><li><span><a href="1130">Восточноевропейский фолк (lossy)</a></span></li><li><span><a href="1131">Восточноевропейский фолк (lossless)</a></span></li><li><span><a href="1132">Западноевропейский фолк (lossy)</a></span></li><li><span><a href="1133">Западноевропейский фолк (lossless)</a></span></li><li><span><a href="2084">Klezmer и Еврейский фольклор (lossy и lossless)</a></span></li><li><span><a href="1128">Этническая музыка Сибири, Средней и Восточной Азии (lossy)</a></span></li><li><span><a href="1129">Этническая музыка Сибири, Средней и Восточной Азии (lossless)</a></span></li><li><span><a href="1856">Этническая музыка Индии (lossy)</a></span></li><li><span><a href="2430">Этническая музыка Индии (lossless)</a></span></li><li><span><a href="1283">Этническая музыка Африки и Ближнего Востока (lossy)</a></span></li><li><span><a href="2085">Этническая музыка Африки и Ближнего Востока (lossless)</a></span></li><li><span><a href="1282">Фольклорная, Народная, Эстрадная музыка Кавказа и Закавказья (lossy и lossless)</a></span></li><li><span><a href="1284">Этническая музыка Северной и Южной Америки (lossy)</a></span></li><li><span><a href="1285">Этническая музыка Северной и Южной Америки (lossless)</a></span></li><li><span><a href="1138">Этническая музыка Австралии, Тихого и Индийского океанов (lossy и lossless)</a></span></li><li><span><a href="1136">Country, Bluegrass (lossy)</a></span></li><li><span><a href="1137">Country, Bluegrass (lossless)</a></span></li></ul></li><li><span class='b'><a href="1849">New Age, Relax, Meditative &amp; Flamenco</a></span><ul><li><span><a href="1846">Архив (New Age, Relax, Meditative &amp; Flamenco)</a></span></li><li><span><a href="1126">New Age &amp; Meditative (lossy)</a></span></li><li><span><a href="1127">New Age &amp; Meditative (lossless)</a></span></li><li><span><a href="1134">Фламенко и акустическая гитара (lossy)</a></span></li><li><span><a href="1135">Фламенко и акустическая гитара (lossless)</a></span></li><li><span><a href="2018">Музыка для бальных танцев (lossy и lossless)</a></span></li><li><span><a href="855">Звуки природы</a></span></li></ul></li><li><span class='b'><a href="408">Рэп, Хип-Хоп, R&#039;n&#039;B</a></span><ul><li><span><a href="448">Архив (Рэп, Хип-Хоп, R&#039;n&#039;B)</a></span></li><li><span><a href="441">Отечественный Рэп, Хип-Хоп (lossy)</a></span></li><li><span><a href="1173">Отечественный R&#039;n&#039;B (lossy)</a></span></li><li><span><a href="1486">Отечественный Рэп, Хип-Хоп, R&#039;n&#039;B (lossless)</a></span></li><li><span><a href="1172">Зарубежный R&#039;n&#039;B (lossy)</a></span></li><li><span><a href="446">Зарубежный Рэп, Хип-Хоп (lossy)</a></span></li><li><span><a href="909">Зарубежный Рэп, Хип-Хоп (lossless)</a></span></li><li><span><a href="1665">Зарубежный R&#039;n&#039;B (lossless)</a></span></li></ul></li><li><span class='b'><a href="1760">Reggae, Ska, Dub</a></span><ul><li><span><a href="1761">Архив (Reggae, Ska, Dub)</a></span></li><li><span><a href="1764">Rocksteady, Early Reggae, Ska-Jazz, Trad.Ska (lossy и lossless)</a></span></li><li><span><a href="1767">3rd Wave Ska (lossy)</a></span></li><li><span><a href="1769">Ska-Punk, Ska-Core (lossy)</a></span></li><li><span><a href="1765">Reggae (lossy)</a></span></li><li><span><a href="1771">Dub (lossy)</a></span></li><li><span><a href="1770">Dancehall, Raggamuffin (lossy)</a></span></li><li><span><a href="1768">Reggae, Dancehall, Dub (lossless)</a></span></li><li><span><a href="1774">Ska, Ska-Punk, Ska-Jazz (lossless)</a></span></li><li><span><a href="1772">Отечественный Reggae, Ska, Dub (lossy и lossless)</a></span></li><li><span><a href="2233">Reggae, Ska, Dub (компиляции) (lossy и lossless)</a></span></li></ul></li><li><span class='b'><a href="416">Саундтреки, караоке и мюзиклы</a></span><ul><li><span><a href="473">Архив (Саундтреки, караоке и мюзиклы)</a></span></li><li><span><a href="2377">Караоке</a></span></li><li><span><a href="468">Минусовки (lossy и lossless)</a></span></li><li><span><a href="691">Саундтреки к отечественным фильмам (lossless)</a></span></li><li><span><a href="469">Саундтреки к отечественным фильмам (lossy)</a></span></li><li><span><a href="786">Саундтреки к зарубежным фильмам (lossless)</a></span></li><li><span><a href="785">Саундтреки к зарубежным фильмам (lossy)</a></span></li><li><span><a href="1631">Саундтреки к сериалам (lossless)</a></span></li><li><span><a href="1499">Саундтреки к сериалам (lossy)</a></span></li><li><span><a href="715">Саундтреки к мультфильмам (lossy и lossless)</a></span></li><li><span><a href="1388">Саундтреки к аниме (lossless)</a></span></li><li><span><a href="282">Саундтреки к аниме (lossy)</a></span></li><li><span><a href="796">Неофициальные саундтреки к фильмам и сериалам (lossy)</a></span></li><li><span><a href="784">Саундтреки к играм (lossless)</a></span></li><li><span><a href="783">Саундтреки к играм (lossy)</a></span></li><li><span><a href="2331">Неофициальные саундтреки к играм (lossy)</a></span></li><li><span><a href="2431">Аранжировки музыки из игр (lossy и lossless)</a></span></li><li><span><a href="880">Мюзикл (lossy и lossless)</a></span></li></ul></li><li><span class='b'><a href="1215">Шансон, Авторская и Военная песня</a></span><ul><li><span><a href="1218">Архив (Шансон, Авторская и Военная песня)</a></span></li><li><span><a href="1220">Отечественный шансон (lossless)</a></span></li><li><span><a href="1221">Отечественный шансон (lossy)</a></span></li><li><span><a href="1334">Сборники отечественного шансона (lossy)</a></span></li><li><span><a href="1216">Военная песня, марши (lossless)</a></span></li><li><span><a href="1223">Военная песня, марши (lossy)</a></span></li><li><span><a href="1224">Авторская песня (lossless)</a></span></li><li><span><a href="1225">Авторская песня (lossy)</a></span></li><li><span><a href="1226">Менестрели и ролевики (lossy и lossless)</a></span></li></ul></li><li><span class='b'><a href="782">Лейбл- и сцен-паки. Неофициальные сборники и ремастеринги. AI-музыка</a></span><ul><li><span><a href="935">Архив (Лейбл- и Сцен-паки. Неофициальные сборники и ремастеринги)</a></span></li><li><span><a href="577">AI-Music - музыка ИИ, нейросетей (lossy и lossless)</a></span></li><li><span><a href="1842">Лейбл-паки (lossless)</a></span></li><li><span><a href="1648">Лейбл-паки, Сцен-паки (lossy)</a></span></li><li><span><a href="134">Неофициальные сборники и ремастеринги (lossless)</a></span></li><li><span><a href="965">Неофициальные сборники (lossy)</a></span></li></ul></li></ul></li></ul>
+<ul class='tree-root'><li><span class='b'><span class="c-title" title="Популярная музыка"></span></span><ul><li><span class='b'><a href="2495">Отечественная поп-музыка</a></span><ul><li><span><a href="2496">Архив (Отечественная поп-музыка)</a></span></li><li><span><a href="424">Популярная музыка России и стран бывшего СССР (lossy)</a></span></li><li><span><a href="1361">Популярная музыка России и стран бывшего СССР (сборники) (lossy)</a></span></li><li><span><a href="425">Популярная музыка России и стран бывшего СССР (lossless)</a></span></li><li><span><a href="1635">Советская эстрада, ретро, романсы (lossy)</a></span></li><li><span><a href="1634">Советская эстрада, ретро, романсы (lossless)</a></span></li></ul></li><li><span class='b'><a href="2497">Зарубежная поп-музыка</a></span><ul><li><span><a href="2498">Архив (Зарубежная поп-музыка)</a></span></li><li><span><a href="428">Зарубежная поп-музыка (lossy)</a></span></li><li><span><a href="1362">Зарубежная поп-музыка (сборники) (lossy)</a></span></li><li><span><a href="429">Зарубежная поп-музыка (lossless)</a></span></li><li><span><a href="735">Итальянская поп-музыка (lossy)</a></span></li><li><span><a href="1753">Итальянская поп-музыка (lossless)</a></span></li><li><span><a href="2232">Латиноамериканская поп-музыка (lossy)</a></span></li><li><span><a href="714">Латиноамериканская поп-музыка (lossless)</a></span></li><li><span><a href="1331">Восточноазиатская поп-музыка (lossy)</a></span></li><li><span><a href="1330">Восточноазиатская поп-музыка (lossless)</a></span></li><li><span><a href="1219">Зарубежный шансон (lossy)</a></span></li><li><span><a href="1452">Зарубежный шансон (lossless)</a></span></li><li><span><a href="2275">Easy Listening, Instrumental Pop (lossy)</a></span></li><li><span><a href="2270">Easy Listening, Instrumental Pop (lossless)</a></span></li><li><span><a href="1351">Сборники песен для детей (lossy и lossless)</a></span></li></ul></li><li><span class='b'><a href="2499">Eurodance, Disco, Hi-NRG</a></span><ul><li><span><a href="2506">Архив (Eurodance, Disco, Hi-NRG)</a></span></li><li><span><a href="2503">Eurodance, Euro-House, Technopop (lossy)</a></span></li><li><span><a href="2504">Eurodance, Euro-House, Technopop (сборники) (lossy)</a></span></li><li><span><a href="2502">Eurodance, Euro-House, Technopop (lossless)</a></span></li><li><span><a href="2501">Disco, Italo-Disco, Euro-Disco, Hi-NRG (lossy)</a></span></li><li><span><a href="2505">Disco, Italo-Disco, Euro-Disco, Hi-NRG (сборники) (lossy)</a></span></li><li><span><a href="2500">Disco, Italo-Disco, Euro-Disco, Hi-NRG (lossless)</a></span></li></ul></li></ul></li></ul>
+<ul class='tree-root'><li><span class='b'><span class="c-title" title="Джазовая и Блюзовая музыка"></span></span><ul><li><span class='b'><a href="2267">Зарубежный джаз</a></span><ul><li><span><a href="2299">Общение на джазовые темы</a></span></li><li><span><a href="2272">Архив (Зарубежный джаз)</a></span></li><li><span><a href="2277">Early Jazz, Swing, Gypsy (lossless)</a></span></li><li><span><a href="2278">Bop (lossless)</a></span></li><li><span><a href="2279">Mainstream Jazz, Cool (lossless)</a></span></li><li><span><a href="2280">Jazz Fusion (lossless)</a></span></li><li><span><a href="2281">World Fusion, Ethnic Jazz (lossless)</a></span></li><li><span><a href="2282">Avant-Garde Jazz, Free Improvisation (lossless)</a></span></li><li><span><a href="2353">Modern Creative, Third Stream (lossless)</a></span></li><li><span><a href="2284">Smooth, Jazz-Pop (lossless)</a></span></li><li><span><a href="2285">Vocal Jazz (lossless)</a></span></li><li><span><a href="2283">Funk, Soul, R&amp;B (lossless)</a></span></li><li><span><a href="2286">Сборники зарубежного джаза (lossless)</a></span></li><li><span><a href="2287">Зарубежный джаз (lossy)</a></span></li></ul></li><li><span class='b'><a href="2268">Зарубежный блюз</a></span><ul><li><span><a href="2300">Общение на блюзовые темы</a></span></li><li><span><a href="2273">Архив (Зарубежный блюз)</a></span></li><li><span><a href="2293">Blues (Texas, Chicago, Modern and Others) (lossless)</a></span></li><li><span><a href="2292">Blues-rock (lossless)</a></span></li><li><span><a href="2290">Roots, Pre-War Blues, Early R&amp;B, Gospel (lossless)</a></span></li><li><span><a href="2289">Зарубежный блюз (сборники; Tribute VA) (lossless)</a></span></li><li><span><a href="2288">Зарубежный блюз (lossy)</a></span></li></ul></li><li><span class='b'><a href="2269">Отечественный джаз и блюз</a></span><ul><li><span><a href="2274">Архив (Отечественный джаз и блюз)</a></span></li><li><span><a href="2297">Отечественный джаз (lossless)</a></span></li><li><span><a href="2295">Отечественный джаз (lossy)</a></span></li><li><span><a href="2296">Отечественный блюз (lossless)</a></span></li><li><span><a href="2298">Отечественный блюз (lossy)</a></span></li></ul></li></ul></li></ul>
+<ul class='tree-root'><li><span class='b'><span class="c-title" title="Рок-музыка"></span></span><ul><li><span class='b'><a href="1698">Зарубежный Rock</a></span><ul><li><span><a href="733">Архив (Зарубежный Rock)</a></span></li><li><span><a href="1702">Classic Rock &amp; Hard Rock (lossless)</a></span></li><li><span><a href="1703">Classic Rock &amp; Hard Rock (lossy)</a></span></li><li><span><a href="1704">Progressive &amp; Art-Rock (lossless)</a></span></li><li><span><a href="1705">Progressive &amp; Art-Rock (lossy)</a></span></li><li><span><a href="1706">Folk-Rock (lossless)</a></span></li><li><span><a href="1707">Folk-Rock (lossy)</a></span></li><li><span><a href="2329">AOR (Melodic Hard Rock, Arena rock) (lossless)</a></span></li><li><span><a href="2330">AOR (Melodic Hard Rock, Arena rock) (lossy)</a></span></li><li><span><a href="1708">Pop-Rock &amp; Soft Rock (lossless)</a></span></li><li><span><a href="1709">Pop-Rock &amp; Soft Rock (lossy)</a></span></li><li><span><a href="1710">Instrumental Guitar Rock (lossless)</a></span></li><li><span><a href="1711">Instrumental Guitar Rock (lossy)</a></span></li><li><span><a href="1712">Rockabilly, Psychobilly, Rock&#039;n&#039;Roll (lossless)</a></span></li><li><span><a href="1713">Rockabilly, Psychobilly, Rock&#039;n&#039;Roll (lossy)</a></span></li><li><span><a href="731">Сборники зарубежного рока (lossless)</a></span></li><li><span><a href="1799">Сборники зарубежного рока (lossy)</a></span></li><li><span><a href="1714">Восточноазиатский рок (lossless)</a></span></li><li><span><a href="1715">Восточноазиатский рок (lossy)</a></span></li></ul></li><li><span class='b'><a href="1716">Зарубежный Metal</a></span><ul><li><span><a href="1717">Архив (Зарубежный Metal)</a></span></li><li><span><a href="1718">Для общения пользователей (Metal)</a></span></li><li><span><a href="1796">Avant-garde, Experimental Metal (lossless)</a></span></li><li><span><a href="1797">Avant-garde, Experimental Metal (lossy)</a></span></li><li><span><a href="1719">Black (lossless)</a></span></li><li><span><a href="1778">Black (lossy)</a></span></li><li><span><a href="1779">Death, Doom (lossless)</a></span></li><li><span><a href="1780">Death, Doom (lossy)</a></span></li><li><span><a href="1720">Folk, Pagan, Viking (lossless)</a></span></li><li><span><a href="798">Folk, Pagan, Viking (lossy)</a></span></li><li><span><a href="1724">Gothic Metal (lossless)</a></span></li><li><span><a href="1725">Gothic Metal (lossy)</a></span></li><li><span><a href="1730">Grind, Brutal Death (lossless)</a></span></li><li><span><a href="1731">Grind, Brutal Death (lossy)</a></span></li><li><span><a href="1726">Heavy, Power, Progressive (lossless)</a></span></li><li><span><a href="1727">Heavy, Power, Progressive (lossy)</a></span></li><li><span><a href="1815">Sludge, Stoner, Post-Metal (lossless)</a></span></li><li><span><a href="1816">Sludge, Stoner, Post-Metal (lossy)</a></span></li><li><span><a href="1728">Thrash, Speed (lossless)</a></span></li><li><span><a href="1729">Thrash, Speed (lossy)</a></span></li><li><span><a href="2230">Сборники (lossless)</a></span></li><li><span><a href="2231">Сборники (lossy)</a></span></li></ul></li><li><span class='b'><a href="1732">Зарубежные Alternative, Punk, Independent</a></span><ul><li><span><a href="1733">Архив (Alternative, Punk, Independent)</a></span></li><li><span><a href="1736">Alternative &amp; Nu-metal (lossless)</a></span></li><li><span><a href="1737">Alternative &amp; Nu-metal (lossy)</a></span></li><li><span><a href="1738">Punk (lossless)</a></span></li><li><span><a href="1739">Punk (lossy)</a></span></li><li><span><a href="1740">Hardcore (lossless)</a></span></li><li><span><a href="1741">Hardcore (lossy)</a></span></li><li><span><a href="1773">Indie Rock, Indie Pop, Dream Pop, Brit-Pop (lossless)</a></span></li><li><span><a href="202">Indie Rock, Indie Pop, Dream Pop, Brit-Pop (lossy)</a></span></li><li><span><a href="172">Post-Punk, Shoegaze, Garage Rock, Noise Rock (lossless)</a></span></li><li><span><a href="236">Post-Punk, Shoegaze, Garage Rock, Noise Rock (lossy)</a></span></li><li><span><a href="1742">Post-Rock (lossless)</a></span></li><li><span><a href="1743">Post-Rock (lossy)</a></span></li><li><span><a href="1744">Industrial &amp; Post-industrial (lossless)</a></span></li><li><span><a href="1745">Industrial &amp; Post-industrial (lossy)</a></span></li><li><span><a href="1746">Emocore, Post-hardcore, Metalcore (lossless)</a></span></li><li><span><a href="1747">Emocore, Post-hardcore, Metalcore (lossy)</a></span></li><li><span><a href="1748">Gothic Rock &amp; Dark Folk (lossless)</a></span></li><li><span><a href="1749">Gothic Rock &amp; Dark Folk (lossy)</a></span></li><li><span><a href="2175">Avant-garde, Experimental Rock (lossless)</a></span></li><li><span><a href="2174">Avant-garde, Experimental Rock (lossy)</a></span></li></ul></li><li><span class='b'><a href="722">Отечественный Rock, Metal</a></span><ul><li><span><a href="736">Архив (Отечественный Рок)</a></span></li><li><span><a href="737">Rock (lossless)</a></span></li><li><span><a href="738">Rock (lossy)</a></span></li><li><span><a href="464">Alternative, Punk, Independent (lossless)</a></span></li><li><span><a href="463">Alternative, Punk, Independent (lossy)</a></span></li><li><span><a href="739">Metal (lossless)</a></span></li><li><span><a href="740">Metal (lossy)</a></span></li><li><span><a href="951">Rock на языках народов xUSSR (lossless)</a></span></li><li><span><a href="952">Rock на языках народов xUSSR (lossy)</a></span></li></ul></li></ul></li></ul>
+<ul class='tree-root'><li><span class='b'><span class="c-title" title="Электронная музыка"></span></span><ul><li><span class='b'><a href="1821">Trance, Goa Trance, Psy-Trance, PsyChill, Ambient, Dub</a></span><ul><li><span><a href="1845">Архив (Trance, Goa Trance, Psy-Trance, PsyChill, Ambient, Dub)</a></span></li><li><span><a href="1844">Goa Trance, Psy-Trance (lossless)</a></span></li><li><span><a href="1822">Goa Trance, Psy-Trance (lossy)</a></span></li><li><span><a href="1894">PsyChill, Ambient, Dub (lossless)</a></span></li><li><span><a href="1895">PsyChill, Ambient, Dub (lossy)</a></span></li><li><span><a href="460">Goa Trance, Psy-Trance, PsyChill, Ambient, Dub (Live Sets, Mixes) (lossy)</a></span></li><li><span><a href="1818">Trance (lossless)</a></span></li><li><span><a href="1819">Trance (lossy)</a></span></li><li><span><a href="1847">Trance (Singles, EPs) (lossy)</a></span></li><li><span><a href="1824">Trance (Radioshows, Podcasts, Live Sets, Mixes) (lossy)</a></span></li></ul></li><li><span class='b'><a href="1807">House, Techno, Hardcore, Hardstyle, Jumpstyle</a></span><ul><li><span><a href="1848">Архив (House, Techno, Hardcore, Hardstyle, Jumpstyle)</a></span></li><li><span><a href="1829">Hardcore, Hardstyle, Jumpstyle (lossless)</a></span></li><li><span><a href="1830">Hardcore, Hardstyle, Jumpstyle (lossy)</a></span></li><li><span><a href="1831">Hardcore, Hardstyle, Jumpstyle (vinyl, web)</a></span></li><li><span><a href="1857">House (lossless)</a></span></li><li><span><a href="1859">House (Radioshow, Podcast, Liveset, Mixes)</a></span></li><li><span><a href="1858">House (lossy)</a></span></li><li><span><a href="840">House (Проморелизы, сборники) (lossy)</a></span></li><li><span><a href="1860">House (Singles, EPs) (lossy)</a></span></li><li><span><a href="1825">Techno (lossless)</a></span></li><li><span><a href="1826">Techno (lossy)</a></span></li><li><span><a href="1827">Techno (Radioshows, Podcasts, Livesets, Mixes)</a></span></li><li><span><a href="1828">Techno (Singles, EPs) (lossy)</a></span></li></ul></li><li><span class='b'><a href="1808">Drum &amp; Bass, Jungle, Breakbeat, Dubstep, IDM, Electro</a></span><ul><li><span><a href="1851">Архив (Drum &amp; Bass, Jungle, Electro, Breakbeat, IDM)</a></span></li><li><span><a href="797">Electro, Electro-Freestyle, Nu Electro (lossless)</a></span></li><li><span><a href="1805">Electro, Electro-Freestyle, Nu Electro (lossy)</a></span></li><li><span><a href="1832">Drum &amp; Bass, Jungle (lossless)</a></span></li><li><span><a href="1833">Drum &amp; Bass, Jungle (lossy)</a></span></li><li><span><a href="1834">Drum &amp; Bass, Jungle (Radioshows, Podcasts, Livesets, Mixes)</a></span></li><li><span><a href="1836">Breakbeat (lossless)</a></span></li><li><span><a href="1837">Breakbeat (lossy)</a></span></li><li><span><a href="1839">Dubstep (lossless)</a></span></li><li><span><a href="454">Dubstep (lossy)</a></span></li><li><span><a href="1838">Breakbeat, Dubstep (Radioshows, Podcasts, Livesets, Mixes)</a></span></li><li><span><a href="1840">IDM (lossless)</a></span></li><li><span><a href="1841">IDM (lossy)</a></span></li><li><span><a href="2229">IDM Discography &amp; Collections (lossy)</a></span></li></ul></li><li><span class='b'><a href="1809">Chillout, Lounge, Downtempo, Trip-Hop</a></span><ul><li><span><a href="1854">Архив (Chillout, Lounge, Downtempo, Trip-Hop)</a></span></li><li><span><a href="1861">Chillout, Lounge, Downtempo (lossless)</a></span></li><li><span><a href="1862">Chillout, Lounge, Downtempo (lossy)</a></span></li><li><span><a href="1947">Nu Jazz, Acid Jazz, Future Jazz (lossless)</a></span></li><li><span><a href="1946">Nu Jazz, Acid Jazz, Future Jazz (lossy)</a></span></li><li><span><a href="1945">Trip Hop, Abstract Hip-Hop (lossless)</a></span></li><li><span><a href="1944">Trip Hop, Abstract Hip-Hop (lossy)</a></span></li></ul></li><li><span class='b'><a href="1810">Traditional Electronic, Ambient, Modern Classical, Electroacoustic, Experimental</a></span><ul><li><span><a href="1870">Архив (Traditional Electronic, Ambient, Experimental)</a></span></li><li><span><a href="1864">Traditional Electronic, Ambient (lossless)</a></span></li><li><span><a href="1865">Traditional Electronic, Ambient (lossy)</a></span></li><li><span><a href="1871">Modern Classical, Electroacoustic (lossless)</a></span></li><li><span><a href="1867">Modern Classical, Electroacoustic (lossy)</a></span></li><li><span><a href="1869">Experimental (lossless)</a></span></li><li><span><a href="1873">Experimental (lossy)</a></span></li></ul></li><li><span class='b'><a href="1811">Industrial, Noise, EBM, Dark Electro, Aggrotech, Cyberpunk, Synthpop, New Wave</a></span><ul><li><span><a href="1883">Архив (Industrial, Noise, EBM, Dark Electro, Aggrotech, Synthpop, New Wave)</a></span></li><li><span><a href="1868">EBM, Dark Electro, Aggrotech (lossless)</a></span></li><li><span><a href="1875">EBM, Dark Electro, Aggrotech (lossy)</a></span></li><li><span><a href="1877">Industrial, Noise (lossless)</a></span></li><li><span><a href="1878">Industrial, Noise (lossy)</a></span></li><li><span><a href="1907">Cyberpunk, 8-bit, Chiptune (lossy &amp; lossless)</a></span></li><li><span><a href="1880">Synthpop, Futurepop, New Wave, Electropop (lossless)</a></span></li><li><span><a href="1881">Synthpop, Futurepop, New Wave, Electropop (lossy)</a></span></li><li><span><a href="466">Synthwave, Spacesynth, Dreamwave, Retrowave, Outrun (lossless)</a></span></li><li><span><a href="465">Synthwave, Spacesynth, Dreamwave, Retrowave, Outrun (lossy)</a></span></li><li><span><a href="1866">Darkwave, Neoclassical, Ethereal, Dungeon Synth (lossless)</a></span></li><li><span><a href="406">Darkwave, Neoclassical, Ethereal, Dungeon Synth (lossy)</a></span></li></ul></li></ul></li></ul>
+<ul class='tree-root'><li><span class='b'><span class="c-title" title="Hi-Res форматы, оцифровки"></span></span><ul><li><span class='b'><a href="1239">Архив (Hi-Res форматы, оцифровки)</a></span></li><li><span class='b'><a href="1785">Для общения (Hi-Res, оцифровки)</a></span><ul><li><span><a href="1115">Инструкции по оцифровкам, Hi-Res и многоканальному аудио</a></span></li></ul></li><li><span class='b'><a href="1299">Hi-Res stereo и многоканальная музыка</a></span><ul><li><span><a href="1884">Классика и классика в современной обработке (Hi-Res stereo)</a></span></li><li><span><a href="1164">Классика и классика в современной обработке (многоканальная музыка)</a></span></li><li><span><a href="2513">New Age, Relax, Meditative &amp; Flamenco (Hi-Res stereo и многоканальная музыка)</a></span></li><li><span><a href="1397">Саундтреки (Hi-Res stereo и многоканальная музыка)</a></span></li><li><span><a href="2512">Музыка разных жанров (Hi-Res stereo и многоканальная музыка)</a></span></li><li><span><a href="1885">Поп-музыка (Hi-Res stereo)</a></span></li><li><span><a href="1163">Поп-музыка (многоканальная музыка)</a></span></li><li><span><a href="2302">Джаз и Блюз (Hi-Res stereo)</a></span></li><li><span><a href="2303">Джаз и Блюз (многоканальная музыка)</a></span></li><li><span><a href="1755">Рок-музыка (Hi-Res stereo)</a></span></li><li><span><a href="1757">Рок-музыка (многоканальная музыка)</a></span></li><li><span><a href="1893">Электронная музыка (Hi-Res stereo)</a></span></li><li><span><a href="1890">Электронная музыка (многоканальная музыка)</a></span></li></ul></li><li><span class='b'><a href="2219">Оцифровки с аналоговых носителей</a></span><ul><li><span><a href="1660">Классика и классика в современной обработке (оцифровки)</a></span></li><li><span><a href="506">Фольклор, народная и этническая музыка (оцифровки)</a></span></li><li><span><a href="1835">Rap, Hip-Hop, R&#039;n&#039;B, Reggae, Ska, Dub (оцифровки)</a></span></li><li><span><a href="1625">Саундтреки и мюзиклы (оцифровки)</a></span></li><li><span><a href="1217">Шансон, авторские, военные песни и марши (оцифровки)</a></span></li><li><span><a href="974">Музыка других жанров (оцифровки)</a></span></li><li><span><a href="1444">Зарубежная поп-музыка (оцифровки)</a></span></li><li><span><a href="2401">Советская эстрада, ретро, романсы (оцифровки)</a></span></li><li><span><a href="239">Отечественная поп-музыка (оцифровки)</a></span></li><li><span><a href="450">Инструментальная поп-музыка (оцифровки)</a></span></li><li><span><a href="2301">Джаз и блюз (оцифровки)</a></span></li><li><span><a href="123">Alternative, Punk, Independent (оцифровки)</a></span></li><li><span><a href="1756">Зарубежная рок-музыка (оцифровки)</a></span></li><li><span><a href="1758">Отечественная рок-музыка (оцифровки)</a></span></li><li><span><a href="1766">Зарубежный и Отечественный Metal (оцифровки)</a></span></li><li><span><a href="1754">Электронная музыка (оцифровки)</a></span></li></ul></li><li><span class='b'><a href="860">Неофициальные конверсии цифровых форматов</a></span><ul><li><span><a href="453">Конверсии Quadraphonic</a></span></li><li><span><a href="1170">Конверсии SACD</a></span></li><li><span><a href="1759">Конверсии Blu-Ray, ADVD и DVD-Audio</a></span></li><li><span><a href="1852">Апмиксы-Upmixes</a></span></li></ul></li></ul></li></ul>
+<ul class='tree-root'><li><span class='b'><span class="c-title" title="Музыкальное видео"></span></span><ul><li><span class='b'><a href="1853">Помощь по музыкальным видео</a></span><ul><li><span><a href="1455">Правила и Инструкции по работе с Видео, DVD Видео, HD Видео</a></span></li><li><span><a href="2510">Для общения пользователей</a></span></li></ul></li><li><span class='b'><a href="413">Музыкальное SD видео</a></span><ul><li><span><a href="2402">Архив (Музыкальное SD видео)</a></span></li><li><span><a href="445">Классическая и современная академическая музыка (Видео)</a></span></li><li><span><a href="702">Опера, Оперетта и Мюзикл (Видео)</a></span></li><li><span><a href="1990">Балет и современная хореография (Видео)</a></span></li><li><span><a href="1793">Классика в современной обработке, Classical Crossover (Видео)</a></span></li><li><span><a href="1141">Фольклор, Народная и Этническая музыка и фламенко (Видео)</a></span></li><li><span><a href="1775">New Age, Relax, Meditative, Рэп, Хип-Хоп, R&#039;n&#039;B, Reggae, Ska, Dub (Видео)</a></span></li><li><span><a href="1227">Зарубежный и Отечественный Шансон, Авторская и Военная песня (Видео)</a></span></li><li><span><a href="475">Музыка других жанров, Советская эстрада, ретро, романсы (Видео)</a></span></li><li><span><a href="1121">Отечественная поп-музыка (Видео)</a></span></li><li><span><a href="431">Зарубежная Поп-музыка, Eurodance, Disco (Видео)</a></span></li><li><span><a href="2378">Восточноазиатская поп-музыка (Видео)</a></span></li><li><span><a href="1039">Восточноазиатский Rock (Видео)</a></span></li><li><span><a href="2383">Разножанровые сборные концерты и сборники видеоклипов (Видео)</a></span></li><li><span><a href="2305">Джаз и Блюз (Видео)</a></span></li><li><span><a href="1782">Rock (Видео)</a></span></li><li><span><a href="1787">Metal (Видео)</a></span></li><li><span><a href="1789">Зарубежный Alternative, Punk, Independent (Видео)</a></span></li><li><span><a href="1791">Отечественный Рок, Панк, Альтернатива (Видео)</a></span></li><li><span><a href="1912">Электронная музыка (Видео)</a></span></li><li><span><a href="1189">Документальные фильмы о музыке и музыкантах (Видео)</a></span></li></ul></li><li><span class='b'><a href="2403">Музыкальное DVD видео</a></span><ul><li><span><a href="2391">Архив (Музыкальное DVD Видео)</a></span></li><li><span><a href="984">Классическая и современная академическая музыка (DVD Видео)</a></span></li><li><span><a href="983">Опера, Оперетта и Мюзикл (DVD Видео)</a></span></li><li><span><a href="2352">Балет и современная хореография (DVD Видео)</a></span></li><li><span><a href="2384">Классика в современной обработке, Classical Crossover (DVD Видео)</a></span></li><li><span><a href="1142">Фольклор, Народная и Этническая музыка и Flamenco (DVD Видео)</a></span></li><li><span><a href="1107">New Age, Relax, Meditative, Рэп, Хип-Хоп, R&#039;n&#039;B, Reggae, Ska, Dub (DVD Видео)</a></span></li><li><span><a href="1228">Зарубежный и Отечественный Шансон, Авторская и Военная песня (DVD Видео)</a></span></li><li><span><a href="988">Музыка других жанров, Советская эстрада, ретро, романсы (DVD Видео)</a></span></li><li><span><a href="1122">Отечественная поп-музыка (DVD Видео)</a></span></li><li><span><a href="986">Зарубежная Поп-музыка, Eurodance, Disco (DVD Видео)</a></span></li><li><span><a href="2379">Восточноазиатская поп-музыка (DVD Видео)</a></span></li><li><span><a href="1038">Восточноазиатский Rock (DVD Видео)</a></span></li><li><span><a href="2088">Разножанровые сборные концерты и сборники видеоклипов (DVD Видео)</a></span></li><li><span><a href="2304">Джаз и Блюз (DVD Видео)</a></span></li><li><span><a href="1783">Зарубежный Rock (DVD Видео)</a></span></li><li><span><a href="1788">Зарубежный Metal (DVD Видео)</a></span></li><li><span><a href="1790">Зарубежный Alternative, Punk, Independent (DVD Видео)</a></span></li><li><span><a href="1792">Отечественный Рок, Метал, Панк, Альтернатива (DVD Видео)</a></span></li><li><span><a href="1886">Электронная музыка (DVD Видео)</a></span></li><li><span><a href="2509">Документальные фильмы о музыке и музыкантах (DVD Видео)</a></span></li></ul></li><li><span class='b'><a href="2507">Неофициальные DVD видео</a></span><ul><li><span><a href="2263">Классическая музыка, Опера, Балет, Мюзикл (Неофициальные DVD Видео)</a></span></li><li><span><a href="2511">Шансон, Авторская песня, Сборные концерты, МДЖ (Неофициальные DVD Видео)</a></span></li><li><span><a href="2264">Зарубежная и Отечественная Поп-музыка (Неофициальные DVD Видео)</a></span></li><li><span><a href="2262">Джаз и Блюз (Неофициальные DVD Видео)</a></span></li><li><span><a href="2261">Зарубежная и Отечественная Рок-музыка (Неофициальные DVD Видео)</a></span></li><li><span><a href="1887">Электронная музыка (Неофициальные DVD Видео)</a></span></li><li><span><a href="2531">Прочие жанры (Неофициальные DVD Видео)</a></span></li></ul></li><li><span class='b'><a href="2400">Музыкальное HD видео</a></span><ul><li><span><a href="2399">Архив (Музыкальное HD Видео)</a></span></li><li><span><a href="1812">Классическая и современная академическая музыка (HD Видео)</a></span></li><li><span><a href="655">Опера, Оперетта и Мюзикл (HD Видео)</a></span></li><li><span><a href="1777">Балет и современная хореография (HD Видео)</a></span></li><li><span><a href="2530">Фольклор, Народная, Этническая музыка и Flamenco (HD Видео)</a></span></li><li><span><a href="2529">New Age, Relax, Meditative, Рэп, Хип-Хоп, R&#039;n&#039;B, Reggae, Ska, Dub (HD Видео)</a></span></li><li><span><a href="1781">Музыка других жанров, Разножанровые сборные концерты (HD видео)</a></span></li><li><span><a href="2508">Зарубежная поп-музыка (HD Видео)</a></span></li><li><span><a href="2426">Отечественная поп-музыка (HD Видео)</a></span></li><li><span><a href="2351">Восточноазиатская Поп-музыка (HD Видео)</a></span></li><li><span><a href="1340">Восточноазиатский Rock (HD Видео)</a></span></li><li><span><a href="2306">Джаз и Блюз (HD Видео)</a></span></li><li><span><a href="1795">Зарубежный рок (HD Видео)</a></span></li><li><span><a href="2271">Отечественный рок (HD видео)</a></span></li><li><span><a href="1913">Электронная музыка (HD Видео)</a></span></li><li><span><a href="1784">UHD музыкальное видео</a></span></li><li><span><a href="1892">Документальные фильмы о музыке и музыкантах (HD Видео)</a></span></li><li><span><a href="2266">Официальные апскейлы (Blu-ray, HDTV, WEB-DL)</a></span></li></ul></li><li><span class='b'><a href="518">Некондиционное музыкальное видео (Видео, DVD видео, HD видео)</a></span></li></ul></li></ul>
+<ul class='tree-root'><li><span class='b'><span class="c-title" title="Игры"></span></span><ul><li><span class='b'><a href="5">Игры для Windows</a></span><ul><li><span><a href="1151">Поиск и обсуждение игр для Windows</a></span></li><li><span><a href="635">Новинки</a></span></li><li><span><a href="127">Аркады</a></span></li><li><span><a href="2203">Файтинги</a></span></li><li><span><a href="647">Экшены от первого лица</a></span></li><li><span><a href="646">Экшены от третьего лица</a></span></li><li><span><a href="50">Хорроры</a></span></li><li><span><a href="53">Приключения и квесты</a></span></li><li><span><a href="1008">Квесты в стиле &quot;Поиск предметов&quot;</a></span></li><li><span><a href="900">Визуальные новеллы</a></span></li><li><span><a href="128">Для самых маленьких</a></span></li><li><span><a href="2204">Логические игры</a></span></li><li><span><a href="278">Шахматы</a></span></li><li><span><a href="52">Ролевые игры</a></span></li><li><span><a href="54">Симуляторы</a></span></li><li><span><a href="51">Стратегии в реальном времени</a></span></li><li><span><a href="2226">Пошаговые стратегии</a></span></li><li><span><a href="2118">Антологии и сборники игр</a></span></li><li><span><a href="1310">Старые игры (Экшены)</a></span></li><li><span><a href="2410">Старые игры (Ролевые игры)</a></span></li><li><span><a href="2205">Старые игры (Стратегии)</a></span></li><li><span><a href="2225">Старые игры (Приключения и квесты)</a></span></li><li><span><a href="2206">Старые игры (Симуляторы)</a></span></li><li><span><a href="1007">Старые игры (Аркады)</a></span></li><li><span><a href="2228">IBM-PC-несовместимые компьютеры</a></span></li><li><span><a href="68">Архив (Игры)</a></span></li></ul></li><li><span class='b'><a href="139">Прочее для Windows-игр</a></span><ul><li><span><a href="2478">Дополнения для Train Simulator (Railworks), Microsoft Train Simulator</a></span></li><li><span><a href="2480">Моды, дополнения, утилиты, патчи</a></span></li><li><span><a href="2481">Русификаторы</a></span></li></ul></li><li><span class='b'><a href="2142">Прочее для Microsoft Flight Simulator, Prepar3D, X-Plane</a></span><ul><li><span><a href="2060">Сценарии, меши и аэропорты для FS2004, FSX, P3D</a></span></li><li><span><a href="2145">Самолёты и вертолёты для FS2004, FSX, P3D</a></span></li><li><span><a href="2146">Миссии, трафик, звуки, паки и утилиты для FS2004, FSX, P3D</a></span></li><li><span><a href="2143">Сценарии, миссии, трафик, звуки, паки и утилиты для X-Plane</a></span></li><li><span><a href="2012">Самолёты и вертолёты для X-Plane</a></span></li></ul></li><li><span class='b'><a href="960">Игры для Apple Macintosh</a></span><ul><li><span><a href="537">Нативные игры для Mac</a></span></li><li><span><a href="637">Игры для Mac с Wineskin, DOSBox, Cider и другими</a></span></li></ul></li><li><span class='b'><a href="899">Игры для Linux</a></span><ul><li><span><a href="1992">Нативные игры для Linux</a></span></li><li><span><a href="2059">Игры для Linux с Wine, DOSBox и другими</a></span></li></ul></li><li><span class='b'><a href="548">Игры для консолей</a></span><ul><li><span><a href="908">PS</a></span></li><li><span><a href="357">PS2</a></span></li><li><span><a href="886">PS3</a></span></li><li><span><a href="973">PS4</a></span></li><li><span><a href="546">PS5</a></span></li><li><span><a href="1352">PSP</a></span></li><li><span><a href="1116">Игры PS1 для PSP</a></span></li><li><span><a href="595">PS Vita</a></span></li><li><span><a href="887">Original Xbox</a></span></li><li><span><a href="510">Xbox 360</a></span></li><li><span><a href="773">Wii U/Wii/GameCube</a></span></li><li><span><a href="774">3DS/DS</a></span></li><li><span><a href="1605">Switch</a></span></li><li><span><a href="968">Dreamcast</a></span></li><li><span><a href="129">Остальные платформы</a></span></li><li><span><a href="545">Архив (Игры для консолей)</a></span></li></ul></li><li><span class='b'><a href="2185">Видео для консолей</a></span><ul><li><span><a href="2487">Видео для PS Vita</a></span></li><li><span><a href="2182">Фильмы для PSP</a></span></li><li><span><a href="2181">Сериалы для PSP</a></span></li><li><span><a href="2180">Мультфильмы для PSP</a></span></li><li><span><a href="2179">Дорамы для PSP</a></span></li><li><span><a href="2186">Аниме для PSP</a></span></li><li><span><a href="700">Видео для PSP</a></span></li><li><span><a href="1926">Видео для PS3 и других консолей</a></span></li><li><span><a href="2467">Архив (Видео для консолей)</a></span></li></ul></li><li><span class='b'><a href="650">Игры для мобильных устройств</a></span><ul><li><span><a href="2149">Игры для Android</a></span></li><li><span><a href="2420">Игры для Oculus Quest</a></span></li><li><span><a href="1004">Игры для Symbian</a></span></li><li><span><a href="1002">Игры для Windows Mobile</a></span></li></ul></li><li><span class='b'><a href="240">Игровое видео</a></span><ul><li><span><a href="2415">Видеопрохождения игр</a></span></li></ul></li></ul></li></ul>
+<ul class='tree-root'><li><span class='b'><span class="c-title" title="Программы и Дизайн"></span></span><ul><li><span class='b'><a href="216">Правила, помощь, предложения по улучшению категории &quot;Программы и Дизайн&quot;</a></span><ul><li><span><a href="1077">Ищу и предлагаю программу</a></span></li></ul></li><li><span class='b'><a href="1012">Операционные системы от Microsoft</a></span><ul><li><span><a href="1191">Общение (Обсуждения, вопросы/ответы)</a></span></li><li><span><a href="2489">Оригинальные образы Windows</a></span></li><li><span><a href="2523">Сборки Windows 8 и далее</a></span></li><li><span><a href="2153">Сборки Windows XP - Windows 7</a></span></li><li><span><a href="1019">Операционные системы выпущенные до Windows XP</a></span></li><li><span><a href="1021">Серверные ОС (оригинальные + сборки)</a></span></li><li><span><a href="1025">Разное (сборки All-in-One, пакеты обновлений, утилиты, и прочее)</a></span></li><li><span><a href="1017">Архив (Операционные системы от Microsoft)</a></span></li></ul></li><li><span class='b'><a href="1376">Linux, Unix и другие ОС</a></span><ul><li><span><a href="1382">Помощь и общение</a></span></li><li><span><a href="1379">Операционные системы (Linux, Unix)</a></span></li><li><span><a href="1381">Программное обеспечение (Linux, Unix)</a></span></li><li><span><a href="1473">Другие ОС и ПО под них</a></span></li><li><span><a href="1384">Архив (Linux)</a></span></li></ul></li><li><span class='b'><a href="1013">Системные программы</a></span><ul><li><span><a href="1196">Общение (Системные программы)</a></span></li><li><span><a href="1028">Работа с жёстким диском</a></span></li><li><span><a href="1029">Резервное копирование</a></span></li><li><span><a href="1030">Архиваторы и файловые менеджеры</a></span></li><li><span><a href="1031">Программы для настройки и оптимизации ОС</a></span></li><li><span><a href="1032">Сервисное обслуживание компьютера</a></span></li><li><span><a href="1033">Работа с носителями информации</a></span></li><li><span><a href="1034">Информация и диагностика</a></span></li><li><span><a href="1066">Программы для интернет и сетей</a></span></li><li><span><a href="1035">ПО для защиты компьютера (Антивирусное ПО, Фаерволлы)</a></span></li><li><span><a href="1536">Драйверы и прошивки</a></span></li><li><span><a href="1051">Оригинальные диски к компьютерам и комплектующим</a></span></li><li><span><a href="1040">Серверное ПО для Windows</a></span></li><li><span><a href="1041">Изменение интерфейса ОС Windows</a></span></li><li><span><a href="1636">Скринсейверы</a></span></li><li><span><a href="1042">Разное (Системные программы под Windows)</a></span></li><li><span><a href="1026">Архив (Программы и Дизайн)</a></span></li></ul></li><li><span class='b'><a href="1014">Системы для бизнеса, офиса, научной и проектной работы</a></span><ul><li><span><a href="1198">Общение (Системы для бизнеса, офиса, научной и проектной работы)</a></span></li><li><span><a href="2134">Медицина - интерактивный софт</a></span></li><li><span><a href="1060">Всё для дома: кройка, шитьё, кулинария</a></span></li><li><span><a href="1061">Офисные системы</a></span></li><li><span><a href="1062">Системы для бизнеса</a></span></li><li><span><a href="1067">Распознавание текста, звука и синтез речи</a></span></li><li><span><a href="1086">Работа с PDF и DjVu</a></span></li><li><span><a href="1068">Словари, переводчики</a></span></li><li><span><a href="1063">Системы для научной работы</a></span></li><li><span><a href="1087">САПР (общие и машиностроительные)</a></span></li><li><span><a href="1192">САПР (электроника, автоматика, ГАП)</a></span></li><li><span><a href="1088">Программы для архитекторов и строителей</a></span></li><li><span><a href="1193">Библиотеки и проекты для архитекторов и дизайнеров интерьеров</a></span></li><li><span><a href="1071">Прочие справочные системы</a></span></li><li><span><a href="1073">Разное (Системы для бизнеса, офиса, научной и проектной работы)</a></span></li></ul></li><li><span class='b'><a href="1052">Веб-разработка и Программирование</a></span><ul><li><span><a href="307">Общение (Веб-разработка и Программирование)</a></span></li><li><span><a href="1053">WYSIWYG Редакторы для веб-диза</a></span></li><li><span><a href="1054">Текстовые редакторы с подсветкой</a></span></li><li><span><a href="1055">Среды программирования, компиляторы и вспомогательные программы</a></span></li><li><span><a href="1056">Компоненты для сред программирования</a></span></li><li><span><a href="2077">Системы управления базами данных</a></span></li><li><span><a href="1057">Скрипты и движки сайтов, CMS а также расширения к ним</a></span></li><li><span><a href="1018">Шаблоны для сайтов и CMS</a></span></li><li><span><a href="1058">Разное (Веб-разработка и программирование)</a></span></li><li><span><a href="1050">Архив (Веб-разработка и программирование)</a></span></li></ul></li><li><span class='b'><a href="1016">Программы для работы с мультимедиа и 3D</a></span><ul><li><span><a href="1078">Общение (Программы для работы с мультимедиа и 3D)</a></span></li><li><span><a href="1195">Тестовые диски для настройки аудио/видео аппаратуры</a></span></li><li><span><a href="1079">Программные комплекты</a></span></li><li><span><a href="1080">Плагины для программ компании Adobe</a></span></li><li><span><a href="1081">Графические редакторы</a></span></li><li><span><a href="1082">Программы для верстки, печати и работы со шрифтами</a></span></li><li><span><a href="1083">3D моделирование, рендеринг и плагины для них</a></span></li><li><span><a href="1084">Анимация</a></span></li><li><span><a href="1085">Создание BD/HD/DVD-видео</a></span></li><li><span><a href="1089">Редакторы видео</a></span></li><li><span><a href="1090">Видео- Аудио- конверторы</a></span></li><li><span><a href="1065">Аудио- и видео-, CD- проигрыватели и каталогизаторы</a></span></li><li><span><a href="1064">Каталогизаторы и просмотрщики графики</a></span></li><li><span><a href="1092">Разное (Программы для работы с мультимедиа и 3D)</a></span></li><li><span><a href="1204">Виртуальные студии, секвенсоры и аудиоредакторы</a></span></li><li><span><a href="1027">Виртуальные инструменты и синтезаторы</a></span></li><li><span><a href="1199">Плагины для обработки звука</a></span></li><li><span><a href="1091">Разное (Программы для работы со звуком)</a></span></li></ul></li><li><span class='b'><a href="828">Материалы для мультимедиа и дизайна</a></span><ul><li><span><a href="838">Ищу/Предлагаю (Материалы для мультимедиа и дизайна)</a></span></li><li><span><a href="1357">Авторские работы</a></span></li><li><span><a href="890">Официальные сборники векторных клипартов</a></span></li><li><span><a href="830">Прочие векторные клипарты</a></span></li><li><span><a href="1290">Photostocks</a></span></li><li><span><a href="1962">Дополнения для программ компоузинга и постобработки</a></span></li><li><span><a href="831">Рамки, шаблоны, текстуры и фоны</a></span></li><li><span><a href="829">Прочие растровые клипарты</a></span></li><li><span><a href="633">3D модели, сцены и материалы</a></span></li><li><span><a href="1009">Футажи</a></span></li><li><span><a href="1963">Прочие сборники футажей</a></span></li><li><span><a href="1954">Музыкальные библиотеки</a></span></li><li><span><a href="1010">Звуковые эффекты</a></span></li><li><span><a href="1674">Библиотеки сэмплов</a></span></li><li><span><a href="2421">Библиотеки и саундбанки для сэмплеров, пресеты для синтезаторов</a></span></li><li><span><a href="2492">Multitracks</a></span></li><li><span><a href="839">Материалы для создания меню и обложек DVD</a></span></li><li><span><a href="1679">Дополнения, стили, кисти, формы, узоры для программ Adobe</a></span></li><li><span><a href="1011">Шрифты</a></span></li><li><span><a href="835">Разное (Материалы для мультимедиа и дизайна)</a></span></li><li><span><a href="837">Архив (Материалы для мультимедиа и дизайна)</a></span></li></ul></li><li><span class='b'><a href="1503">ГИС, системы навигации и карты</a></span><ul><li><span><a href="1506">Общение (ГИС, системы навигации и карты)</a></span></li><li><span><a href="1507">ГИС (Геоинформационные системы)</a></span></li><li><span><a href="1526">Карты, снабженные программной оболочкой</a></span></li><li><span><a href="1508">Атласы и карты современные (после 1950 г.)</a></span></li><li><span><a href="1509">Атласы и карты старинные (до 1950 г.)</a></span></li><li><span><a href="1510">Карты прочие (астрономические, исторические, тематические)</a></span></li><li><span><a href="1511">Встроенная автомобильная навигация</a></span></li><li><span><a href="1512">Garmin</a></span></li><li><span><a href="1513">Ozi</a></span></li><li><span><a href="1514">TomTom</a></span></li><li><span><a href="1515">Navigon / Navitel</a></span></li><li><span><a href="1516">Igo</a></span></li><li><span><a href="1517">Разное - системы навигации и карты</a></span></li></ul></li></ul></li></ul>
+<ul class='tree-root'><li><span class='b'><span class="c-title" title="Мобильные устройства"></span></span><ul><li><span class='b'><a href="285">Приложения для мобильных устройств</a></span><ul><li><span><a href="2154">Приложения для Android</a></span></li><li><span><a href="1005">Приложения для Java</a></span></li><li><span><a href="289">Приложения для Symbian</a></span></li><li><span><a href="290">Приложения для Windows Mobile</a></span></li><li><span><a href="288">Софт для работы с телефоном</a></span></li><li><span><a href="292">Прошивки для телефонов</a></span></li><li><span><a href="291">Обои и темы</a></span></li><li><span><a href="296">Архив (Мобильные устройства)</a></span></li></ul></li><li><span class='b'><a href="957">Видео для мобильных устройств</a></span><ul><li><span><a href="287">Видео для смартфонов и КПК</a></span></li><li><span><a href="286">Видео в формате 3GP для мобильных</a></span></li></ul></li></ul></li></ul>
+<ul class='tree-root'><li><span class='b'><span class="c-title" title="Apple"></span></span><ul><li><span class='b'><a href="1366">Apple Macintosh</a></span><ul><li><span><a href="1368">Mac OS (для Macintosh)</a></span></li><li><span><a href="1383">Mac OS (для РС-Хакинтош)</a></span></li><li><span><a href="1394">Программы для просмотра и обработки видео (Mac OS)</a></span></li><li><span><a href="1370">Программы для создания и обработки графики (Mac OS)</a></span></li><li><span><a href="2237">Плагины для программ компании Adobe (Mac OS)</a></span></li><li><span><a href="1372">Аудио редакторы и конвертеры (Mac OS)</a></span></li><li><span><a href="1373">Системные программы (Mac OS)</a></span></li><li><span><a href="1375">Офисные программы (Mac OS)</a></span></li><li><span><a href="1371">Программы для интернета и сетей (Mac OS)</a></span></li><li><span><a href="1374">Другие программы (Mac OS)</a></span></li><li><span><a href="1393">Архив (Apple Macintosh)</a></span></li></ul></li><li><span class='b'><a href="1933">iOS</a></span><ul><li><span><a href="1935">Программы для iOS</a></span></li><li><span><a href="1003">Игры для iOS</a></span></li><li><span><a href="1937">Разное для iOS</a></span></li><li><span><a href="1934">Архив (iOS)</a></span></li></ul></li><li><span class='b'><a href="2235">Видео</a></span><ul><li><span><a href="1908">Фильмы для iPod, iPhone, iPad</a></span></li><li><span><a href="864">Сериалы для iPod, iPhone, iPad</a></span></li><li><span><a href="863">Мультфильмы для iPod, iPhone, iPad</a></span></li><li><span><a href="2535">Аниме для iPod, iPhone, iPad</a></span></li><li><span><a href="2534">Музыкальное видео для iPod, iPhone, iPad</a></span></li><li><span><a href="2239">Архив (Видео)</a></span></li></ul></li><li><span class='b'><a href="2238">Видео HD</a></span><ul><li><span><a href="1936">Фильмы HD для Apple TV</a></span></li><li><span><a href="315">Сериалы HD для Apple TV</a></span></li><li><span><a href="1363">Мультфильмы HD для Apple TV</a></span></li><li><span><a href="2082">Документальное видео HD для Apple TV</a></span></li><li><span><a href="2241">Музыкальное видео HD для Apple TV</a></span></li><li><span><a href="405">Архив (Видео HD)</a></span></li></ul></li><li><span class='b'><a href="2236">Аудио</a></span><ul><li><span><a href="1909">Аудиокниги (AAC, ALAC)</a></span></li><li><span><a href="1927">Музыка lossless (ALAC)</a></span></li><li><span><a href="2240">Музыка Lossy (AAC-iTunes)</a></span></li><li><span><a href="2248">Музыка Lossy (AAC)</a></span></li><li><span><a href="2244">Музыка Lossy (AAC) (Singles, EPs)</a></span></li><li><span><a href="2242">Архив (Аудио)</a></span></li></ul></li><li><span class='b'><a href="2243">F.A.Q.</a></span><ul><li><span><a href="2257">Вопросы-ответы Mac OS (для PC- Хакинтош)</a></span></li><li><span><a href="2256">Вопросы-ответы MAC OS (для Macintosh)</a></span></li><li><span><a href="2245">iOS</a></span></li><li><span><a href="2246">Аудио и Видео</a></span></li></ul></li></ul></li></ul>
+<ul class='tree-root'><li><span class='b'><span class="c-title" title="Разное"></span></span><ul><li><span class='b'><a href="10">Разное (раздачи)</a></span><ul><li><span><a href="760">Предложения по улучшению раздела &quot;Разное&quot;, помощь по разделу</a></span></li><li><span><a href="491">Архив (Разное)</a></span></li><li><span><a href="865">Психоактивные аудиопрограммы</a></span></li><li><span><a href="1100">Аватары, Иконки, Смайлы</a></span></li><li><span><a href="1643">Живопись, Графика, Скульптура, Digital Art</a></span></li><li><span><a href="848">Картинки</a></span></li><li><span><a href="808">Любительские фотографии</a></span></li><li><span><a href="630">Обои</a></span></li><li><span><a href="1664">Фото знаменитостей</a></span></li><li><span><a href="148">Аудио</a></span></li><li><span><a href="807">Видео</a></span></li><li><span><a href="147">Публикации и учебные материалы (тексты)</a></span></li><li><span><a href="847">Трейлеры и дополнительные материалы к фильмам</a></span></li><li><span><a href="1167">Любительские видеоклипы</a></span></li></ul></li></ul></li></ul>
+<ul class='tree-root'><li><span class='b'><span class="c-title" title="Обсуждения, встречи, общение"></span></span><ul><li><span class='b'><a href="13">Для общения пользователей</a></span><ul><li><span><a href="1672">О ситуации с файлообменом в России</a></span></li><li><span><a href="1800">Общественное движение</a></span></li><li><span><a href="1641">Для общения пользователей других ресурсов</a></span></li><li><span><a href="320">Форумные игры</a></span></li><li><span><a href="1406">Флудилка [18+]</a></span></li></ul></li><li><span class='b'><a href="16">Юридический</a></span><ul><li><span><a href="1435">Новости</a></span></li><li><span><a href="1437">Гражданское и Трудовое право</a></span></li><li><span><a href="1438">Административное и Уголовное право</a></span></li><li><span><a href="1439">Процесс</a></span></li><li><span><a href="1440">Общий</a></span></li><li><span><a href="1441">Для студентов</a></span></li></ul></li><li><span class='b'><a href="1342">Бизнес-форум</a></span><ul><li><span><a href="1414">Общий</a></span></li><li><span><a href="1502">Новости бизнеса</a></span></li><li><span><a href="1401">Недвижимость и страхование</a></span></li><li><span><a href="1402">Руководство и Персонал</a></span></li><li><span><a href="1345">Свой бизнес</a></span></li><li><span><a href="1348">Финансы</a></span></li><li><span><a href="1413">Интернет-бизнес</a></span></li></ul></li><li><span class='b'><a href="2448">Раздел Пиратской партии России</a></span><ul><li><span><a href="2451">Пиратская философия</a></span></li><li><span><a href="2450">Вопросы и предложения</a></span></li><li><span><a href="2449">Нужна помощь пиратов</a></span></li></ul></li><li><span class='b'><a href="14">Место сбора для релиз-групп</a></span></li><li><span class='b'><a href="275">Место встречи изменить...</a></span><ul><li><span><a href="322">Архив (Место встречи изменить...)</a></span></li><li><span><a href="321">Отчеты о встречах</a></span></li></ul></li><li><span class='b'><a href="323">Архив (Общий)</a></span></li></ul></li></ul>
+<ul class='tree-root'><li><span class='b'><span class="c-title" title="Приватные форумы"></span></span><ul><li><span class='b'><a href="759">Generation.torrent группа</a></span><ul><li><span><a href="1178">GENERATION.TORRENT - общий раздел</a></span></li><li><span><a href="1177">Классическая и современная академическая музыка</a></span></li><li><span><a href="1165">Рэп, Хип-Хоп, R&#039;n&#039;B</a></span></li><li><span><a href="795">Авторская песня, Шансон</a></span></li><li><span><a href="1338">Музыка разных жанров</a></span></li><li><span><a href="948">Популярная музыка</a></span></li><li><span><a href="1098">Джазовая и блюзовая музыка</a></span></li><li><span><a href="961">Рок, металл</a></span></li><li><span><a href="1312">Электронная музыка</a></span></li></ul></li><li><span class='b'><a href="196">&#127877; НОВОГОДНИЙ РАЗДЕЛ &#127876;</a></span><ul><li><span><a href="776">Разное (открытки, обои, картинки, видео и пр.) [НГ]</a></span></li></ul></li><li><span class='b'><a href="2162">9 Мая - День Победы!</a></span><ul><li><span><a href="1117">Художественные фильмы, сериалы, спектакли, мультфильмы (9 мая)</a></span></li><li><span><a href="907">Документальные фильмы и передачи (9 мая)</a></span></li><li><span><a href="1624">Парады Победы. Минуты молчания (9 мая)</a></span></li><li><span><a href="2541">Литература документальная (9 мая)</a></span></li><li><span><a href="2381">Литература художественная, ноты, комиксы, моделизм и пр. (9 мая)</a></span></li><li><span><a href="1461">Аудиокниги (9 мая)</a></span></li><li><span><a href="859">Музыка (9 мая)</a></span></li><li><span><a href="858">Музыкальное видео (9 мая)</a></span></li><li><span><a href="1241">Игры для Windows и др. ОС (9 мая)</a></span></li><li><span><a href="2108">Разное: фото, картинки, аудиозаписи, видео и др. (9 мая)</a></span></li></ul></li></ul></li></ul>		</div>
+
+	</div>
+</div>
+
+
+
+			</td>
+			<td style="width: 240px; vertical-align: top; padding-left: 2px;">
+				<div id="idx-sidebar2">
+
+	<div class="sb2-block">
+<h3>Авторские раздачи</h3>
+<ul>
+	<li><a class="bold" href="viewtopic.php?t=6838706">(Ambient, Dark Ambient, Drone, Downtempo, Field Recordings) SiJ - Eden - 2026</a></li>
+<li><a class="bold" href="viewtopic.php?t=6828883">(Industrial/<wbr>Rhythmic Noise/Ambien<wbr>t/Dark Ambient/IDM/<wbr>Post-Rock) Notexist - Mental Anomalies (2026)</a></li>
+<li><a class="bold" href="viewtopic.php?t=6811050">(Electronic,<wbr> Ambient) Flowerbloom - Explore Yourself, Find Yourself - 2025</a></li>
+<li><a class="bold" href="viewtopic.php?t=6795664">(Electronic/<wbr>Dark Electronic/A<wbr>mbient) The Black Renegade - Озеро Лесное - 2025</a></li>
+<li><a  href="viewtopic.php?t=6870279">(metal, black, blackened punk, sludge hadrcore) СОБЕСЕДНИК - ПОСЛЕДСТВИЕ - 2026</a></li>
+<li><a  href="viewtopic.php?t=6870276">(Dark Ambient, Black Ambient) Men Songs - Striving for non-existenc<wbr>e - 2024</a></li>
+<li><a  href="viewtopic.php?t=6870275">(Psychedelic<wbr>/experimenta<wbr>l rock) Партизаны Против Public Relations / Дали - Дискография (16 релизов) - 1993-2016</a></li>
+<li><a  href="viewtopic.php?t=6870273">(Reggae / Alternative Rock / Blues / Rock-n-roll / Instrumental<wbr> / Experimental<wbr>) Jan Wize studio - Дискография:<wbr> 17 релизов (2006-2026)</a></li>
+<li><a  href="viewtopic.php?t=6860489">(Techno-Folk<wbr>) ROOKAVA - 9 singles - 2025-2026</a></li>
+<li><a  href="viewtopic.php?t=6860487">(parody/folk<wbr>) The StarПёры - Ничего святого - 2026</a></li>
+<li><a  href="viewtopic.php?t=6860486">(Progressive<wbr> Death/Thrash<wbr> Metal) Incarnator - Argumentum Ad Ignorantiam - 2017</a></li>
+<li><a  href="viewtopic.php?t=6860484">(Stoner / Metal / Progressive / Sludge) Solar Hammer - Дискография - 2025</a></li>
+	<li><a href="viewforum.php?f=1538"><i>другие раздачи...</i></a></li>
+</ul>
+</div>
+
+	
+	<div class="sb2-block sb2-bg2">
+<h3>Новости &quot;Хранителей&quot; и &quot;Антикваров&quot;</h3>
+<ul>
+	<li><a class="bold" href="viewtopic.php?t=6737788">Группе Хранители - 15 лет</a></li>
+<li><a class="bold" href="viewtopic.php?t=6579518">Красная книга раздач трекера</a></li>
+<li><a class="bold" href="viewtopic.php?t=6045096">Прием в группу Хранители</a></li>
+<li><a class="bold" href="viewtopic.php?t=4234659">Принимаем заявки на присвоение материалу статуса Антикварного<wbr></a></li>
+<li><a  href="viewtopic.php?t=6174283">О проделанной работе</a></li>
+<li><a  href="viewtopic.php?t=5927700">(Classical) Tenors of Imperial Russia [Аудиозаписи]</a></li>
+<li><a  href="viewtopic.php?t=5908670">Jean Dussouchet - Cours primaire de Grammaire Fran&#231;aise. Brevet &#233;l&#233;mentair<wbr>e / Начальный курс грамматики французского<wbr> языка [Литература учебная]</a></li>
+<li><a  href="viewtopic.php?t=5762105">Сабинин С.К. - Грамматика Исландского языка, 1849 [Литература учебная]</a></li>
+<li><a  href="viewtopic.php?t=5760590">С&#1123;верные<wbr> цв&#1123;ты - 1826-1831 [Литература художественн<wbr>ая]</a></li>
+<li><a  href="viewtopic.php?t=5760243">[Эмулятор] Apple Macintosh 128K (System 1.x) [1984, ENG] [Компьютеры]</a></li>
+	<li><a href="viewforum.php?f=2332"><i>другие раздачи...</i></a></li>
+</ul>
+</div>
+
+	
+</div>
+			</td>
+		</tr>
+		</table>
+
+	</div><!--/forums_wrap-->
+
+</div><!--/forums_list_wrap-->
+
+				</div><!--/main_content_wrap-->
+			</td><!--/main_content-->
+
+		</tr>
+		</table>
+	</div><!--/page_content-->
+
+	<!--page_footer-->
+	<div id="page_footer" class="hide-for-print">
+
+		
+		<div class="clear"></div>
+
+		<nav id="footer-info-links">
+			<div>
+				<a href="info.php?show=user_agreement" rel="nofollow">Условия использования</a>
+				&middot;
+				<a href="info.php?show=advert" rel="nofollow">Реклама на сайте</a>
+				&middot;
+				<a href="info.php?show=copyright_holders" rel="nofollow">Для правообладателей</a>
+				&middot;
+				<a href="info.php?show=press" rel="nofollow">Для прессы</a>
+				&middot;
+				<a href="viewtopic.php?t=2234744">Для провайдеров</a>
+				<!--&middot;-->
+				<!--<a href="http://rutracker.news">Блог</a>-->
+				&middot;
+				<a href="https://rutracker.wiki">Торрентопедия</a>
+			</div>
+			<div>
+				<a href="viewtopic.php?t=1045"><b>Правила</b></a>
+				&middot;
+				<a href="/go/8" rel="nofollow">Кому задать вопрос</a>
+				&middot;
+				<a href="viewforum.php?f=1538">Авторские раздачи</a>
+				&middot;
+				<a href="viewforum.php?f=1289">Конкурсы</a>
+				&middot;
+				<a href="viewforum.php?f=2332">Новости &quot;Хранителей&quot; и &quot;Антикваров&quot;</a>
+				&middot;
+				<a href="#" onclick="return post2url('index.php', {rand_rel: 1});" rel="nofollow">Случайная раздача</a>
+			</div>
+		</nav>
+
+		
+		<div class="tCenter nowrap" style="margin: 18px 4px 4px 4px;">
+								</div>
+
+		<div class="footer-bottom-links">
+			<ul class="inlined middot-separated">
+				<li><a href="groupcp.php?g=104792" rel="nofollow" target="_blank">Администрация</a></li>
+				<li><a href="groupcp.php?g=104787" rel="nofollow" target="_blank">Модераторы</a></li>
+				<li><a href="groupcp.php?g=104841" rel="nofollow" target="_blank">Тех. помощь</a></li>
+				<li><a href="https://t.me/rutracker_news" rel="nofollow" target="_blank">Telegram-канал</a></li>
+			</ul>
+			<div class="wide">
+									<script>
+					$(function () {
+						var title = "";
+						var src = "https://counter.yadro.ru/hit?t44.1;r" + encodeURIComponent(document.referrer) +
+							((typeof (screen) == "undefined") ? "" : ";s" + screen.width + "*" + screen.height + "*" + (screen.colorDepth ? screen.colorDepth : screen.pixelDepth)) +
+							";u" + encodeURIComponent(document.URL) + ";h" + encodeURIComponent(title.substring(0, 80)) + ";" + Math.random();
+						$('<img src="' + src + '" alt="">').on('load', function () {
+							$('#liveinternet').append(this);
+						});
+					});
+					</script>
+					<a id="liveinternet" href="https://www.liveinternet.ru/stat/rutracker.org/index.html?lang=ru" target="_blank"></a>
+							</div>
+			<ul class="inlined middot-separated">
+																							</ul>
+		</div>
+
+	</div><!--/page_footer-->
+</div><!--/page_container-->
+
+
+<div id="ajax-loading"><b>Loading...</b></div>
+<div id="ajax-error"><b>Error</b></div>
+<style>
+#bb-alert-box {
+	width: auto;
+	max-width: 800px;
+	line-height: 18px;
+	display: none;
+}
+#bb-alert-msg {
+	min-width: 400px;
+	max-height: 400px;
+	margin: 50px 20px;
+	padding: 10px;
+	overflow: auto;
+	text-align: center;
+}
+.bb-alert-err {
+	color: #7E0000;
+	background: #FFEEEE;
+	box-shadow: 0 0 20px #B85353;
+	font-weight: bold;
+}
+</style>
+<div id="bb-alert-box">
+	<div id="bb-alert-msg"></div>
+</div>
+<div id="modal-blocker"></div>
+
+<script>
+$(function () {
+	if (!BB.hasET() && BB.getUrlParam('view') !== 'print') {
+		BB.navbar.init();
+	}
+});
+</script>
+<div id="nav-panel" class="nav-hidden-arrow hide-for-print">
+	<div id="nav-up" class="nav-btn" title="Вверх">
+		<span class="nav-icon"></span>
+	</div>
+	<div id="nav-settings" class="nav-btn">
+		<span class="nav-icon" title="Настройки"></span>
+		<ul id="nav-opt-menu">
+			<li class="nav-event" data-event="click">Показывать по клику</li>
+			<li class="nav-event" data-event="mouseenter">Показывать по наведению</li>
+		</ul>
+	</div>
+	<div id="nav-down" class="nav-btn" title="Вниз">
+		<span class="nav-icon"></span>
+	</div>
+	<div class="nav-hidden-overlay"></div>
+</div>
+
+	</div><!--/body_container-->
+
+<script>(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML="window.__CF$cv$params={r:'a10650e7eb17d3f4',t:'MTc4MjI0NzMxMg=='};var a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);";b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script></body>
+</html>

--- a/core/network/rutracker/src/test/resources/fixtures/forum_not_found.html
+++ b/core/network/rutracker/src/test/resources/fixtures/forum_not_found.html
@@ -1,0 +1,354 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+
+<meta charset="Windows-1251">
+
+<title>rutracker.org</title>
+
+<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+<link rel="manifest" href="/manifest.json">
+<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
+<meta name="msapplication-TileColor" content="#2b5797">
+<meta name="msapplication-TileImage" content="/mstile-144x144.png">
+<meta name="theme-color" content="#ffffff">
+
+<link rel="search" type="application/opensearchdescription+xml" title="Поиск на RuTracker.org" href="https://static.rutracker.cc/opensearch.xml">
+
+<script>
+window.BB = {
+	cur_domain: location.hostname.replace(/.*?(([a-z0-9-]+\.){1,2}[a-z0-9-]+)$/, '$1'),
+	form_token: '',
+	opt_js: {},
+
+	IS_GUEST: !!'1',
+	IMG_URL: 'https://static.rutracker.cc/templates/v1/images',
+	SMILES_URL: 'https://static.rutracker.cc/smiles',
+	catId: 0,
+	FORUM_ID: 0,
+	parentForumId: 0,
+		COOKIE_MARK: 'bb_mark_read',
+	};
+BB.cookie_defaults = {
+	domain: '.' + BB.cur_domain,
+	path: "/forum/",
+};
+</script>
+<link href="https://static.rutracker.cc/templates/v1/min/eb83350bae3880e4073b81d26294de5d.all.min.css" rel="stylesheet">
+<script src="https://static.rutracker.cc/templates/v1/min/4e695e8ea9cf5a1dcc7aed231b887c51.lib.min.js"></script>
+<script src="https://static.rutracker.cc/templates/v1/min/3b60ab3546ba966484df4c3099b918ab.bb.min.js"></script>
+
+
+
+<style>
+.invisible-el {
+	/* @include element-invisible(); */
+	clip: rect(1px, 1px, 1px, 1px);
+	height: 1px;
+	overflow: hidden;
+	position: absolute !important;
+	width: 1px;
+}
+.hidden, .menu-sub, #ajax-loading, #ajax-error, var.ajax-params, #modal-blocker, .q-post {
+	display: none;
+}
+/**/
+#logo {
+	min-height: auto;
+}
+/**/
+/* temp */
+/* temp end */
+</style>
+
+<noscript>
+	<style>
+	.sp-body {
+		display: block; /* for bots */
+	}
+	</style>
+</noscript>
+
+</head>
+
+<body class="" style="">
+
+<div id="invisible-heap" class="invisible-el"></div>
+<div id="preload" class="invisible-el"></div>
+
+
+
+<div id="body_container">
+
+		<script>
+	if (top != self && !self.location.hostname.match(BB.allowed_translator_hosts)) {
+		$(function () {
+			$('body').html('<h1 style="text-align: center;"><br><br>Похоже, вас пытаются обмануть<br>frame\'s hostname: ' + self.location.hostname + '</h1>');
+			throw new Error('in frame');
+		});
+	}
+		</script>
+
+	<div id="page_container">
+
+		<div id="page_header" class="hide-for-print">
+
+			<div id="main-nav" class="site-nav clearfix">
+				<ul class="inlined middot-separated floatL">
+					<li>
+						<a href="index.php"><b>Главная</b></a>
+					</li>
+					<li>
+													<a href="tracker.php" rel="nofollow"><b>Трекер</b></a>
+											</li>
+					<li>
+						<a href="search.php" rel="nofollow"><b>Поиск</b></a>
+					</li>
+					<li>
+						<a href="groupcp.php" rel="nofollow"><b>Группы</b></a>
+					</li>
+					<li>
+						<a href="https://rutracker.wiki/" target="_blank"><b>FAQ</b></a>
+					</li>
+					<li>
+						<a href="viewtopic.php?t=6812335" style="color: #7b1fa2;"><b>VPN</b></a>
+					</li>
+					<li>
+						<a href="viewtopic.php?t=1045"><b>Правила</b></a>
+					</li>
+					<li>
+						<a href="viewtopic.php?t=6452965" style="color: #880e4f;"><b>Донаты</b></a>
+					</li>
+									</ul>
+											</div>
+			<!--/main-nav-->
+
+			
+			<div id="logo">
+				<table style="">
+				<tr>
+					<td id="logo-td" style="padding: 3px 7px 3px 15px;">
+						<a href="index.php" class="site-logo-link">
+								<img class="site-logo"
+		src="https://static.rutracker.cc/logo/logo-3.svg"
+		style=""
+		alt="logo">
+							</a>
+					</td>
+					<td class="tCenter w100" style="padding: 6px 10px 0 3px;">
+											</td>
+				</tr>
+				</table>
+			</div>
+			<!--/logo-->
+
+						<div class="topmenu">
+				<table class="w100">
+				<tr>
+					
+					<td class="tCenter pad_2 nowrap">
+						<div>
+															<a href="profile.php?mode=register" rel="nofollow"><b>Регистрация</b></a>
+								&nbsp;&#0183;&nbsp;
+								<a href="#" onclick="BB.toggle_top_login(); return false;" tabindex="5"><b>Вход</b></a>
+
+								<div id="top-login-box">
+									<form id="quick-search-guest" method="get" action="tracker.php">
+										<input id="search-text-guest" type="text" name="nm" value="" tabindex="1" accesskey="q">
+										<input type="submit" value="поиск" tabindex="2">
+									</form>
+									<form id="login-form-quick" method="post" action="login.php" style="display: none;">
+																				<input id="top-login-uname" type="text" name="login_username" tabindex="1" accesskey="l" placeholder="имя">
+										<input id="top-login-pwd" type="password" name="login_password" tabindex="2" placeholder="пароль">
+										<label title="Защищенное соединение" class="login-ssl-block" style="display: none;">
+											<input class="login-ssl" type="checkbox" tabindex="3" checked>SSL
+										</label>
+										<input id="top-login-btn" type="submit" name="login" value="вход" tabindex="4">
+									</form>
+								</div>
+
+								<a href="otp.php" rel="nofollow"><b>Забыли имя или пароль?</b></a>
+													</div>
+					</td>
+
+					
+				</tr>
+				</table>
+			</div><!--/topmenu-->
+			
+			
+		</div>
+		<!--/page_header-->
+
+		
+		<div id="page_content">
+			<table style="width: 100%; border: none;">
+			<tr>
+
+				
+				<td id="main_content">
+					<div id="main_content_wrap">
+
+						
+						
+						
+						
+						<!--/page_header.tpl-->
+<!--========================================================================-->
+
+<div class="spacer_10"></div>
+
+<table class="forumline message">
+<tr>
+	<th>Информация</th>
+</tr>
+<tr>
+	<td>
+				<div class="mrg_16">Такого форума не существует</div>
+						<div class="mrg_12"></div>
+		<div class="mrg_12"><p class="mrg_10"><a href="index.php">Вернуться на главную</a></p></div>
+	</td>
+</tr>
+</table>
+
+<div class="spacer_10"></div>
+
+<!--========================================================================-->
+
+
+				</div><!--/main_content_wrap-->
+			</td><!--/main_content-->
+
+		</tr>
+		</table>
+	</div><!--/page_content-->
+
+	<!--page_footer-->
+	<div id="page_footer" class="hide-for-print">
+
+		
+		<div class="clear"></div>
+
+		<nav id="footer-info-links">
+			<div>
+				<a href="info.php?show=user_agreement" rel="nofollow">Условия использования</a>
+				&middot;
+				<a href="info.php?show=advert" rel="nofollow">Реклама на сайте</a>
+				&middot;
+				<a href="info.php?show=copyright_holders" rel="nofollow">Для правообладателей</a>
+				&middot;
+				<a href="info.php?show=press" rel="nofollow">Для прессы</a>
+				&middot;
+				<a href="viewtopic.php?t=2234744">Для провайдеров</a>
+				<!--&middot;-->
+				<!--<a href="http://rutracker.news">Блог</a>-->
+				&middot;
+				<a href="https://rutracker.wiki">Торрентопедия</a>
+			</div>
+			<div>
+				<a href="viewtopic.php?t=1045"><b>Правила</b></a>
+				&middot;
+				<a href="/go/8" rel="nofollow">Кому задать вопрос</a>
+				&middot;
+				<a href="viewforum.php?f=1538">Авторские раздачи</a>
+				&middot;
+				<a href="viewforum.php?f=1289">Конкурсы</a>
+				&middot;
+				<a href="viewforum.php?f=2332">Новости &quot;Хранителей&quot; и &quot;Антикваров&quot;</a>
+				&middot;
+				<a href="#" onclick="return post2url('index.php', {rand_rel: 1});" rel="nofollow">Случайная раздача</a>
+			</div>
+		</nav>
+
+		
+		<div class="tCenter nowrap" style="margin: 18px 4px 4px 4px;">
+								</div>
+
+		<div class="footer-bottom-links">
+			<ul class="inlined middot-separated">
+				<li><a href="groupcp.php?g=104792" rel="nofollow" target="_blank">Администрация</a></li>
+				<li><a href="groupcp.php?g=104787" rel="nofollow" target="_blank">Модераторы</a></li>
+				<li><a href="groupcp.php?g=104841" rel="nofollow" target="_blank">Тех. помощь</a></li>
+				<li><a href="https://t.me/rutracker_news" rel="nofollow" target="_blank">Telegram-канал</a></li>
+			</ul>
+			<div class="wide">
+									<script>
+					$(function () {
+						var title = "";
+						var src = "https://counter.yadro.ru/hit?t44.1;r" + encodeURIComponent(document.referrer) +
+							((typeof (screen) == "undefined") ? "" : ";s" + screen.width + "*" + screen.height + "*" + (screen.colorDepth ? screen.colorDepth : screen.pixelDepth)) +
+							";u" + encodeURIComponent(document.URL) + ";h" + encodeURIComponent(title.substring(0, 80)) + ";" + Math.random();
+						$('<img src="' + src + '" alt="">').on('load', function () {
+							$('#liveinternet').append(this);
+						});
+					});
+					</script>
+					<a id="liveinternet" href="https://www.liveinternet.ru/stat/rutracker.org/index.html?lang=ru" target="_blank"></a>
+							</div>
+			<ul class="inlined middot-separated">
+																							</ul>
+		</div>
+
+	</div><!--/page_footer-->
+</div><!--/page_container-->
+
+
+<div id="ajax-loading"><b>Loading...</b></div>
+<div id="ajax-error"><b>Error</b></div>
+<style>
+#bb-alert-box {
+	width: auto;
+	max-width: 800px;
+	line-height: 18px;
+	display: none;
+}
+#bb-alert-msg {
+	min-width: 400px;
+	max-height: 400px;
+	margin: 50px 20px;
+	padding: 10px;
+	overflow: auto;
+	text-align: center;
+}
+.bb-alert-err {
+	color: #7E0000;
+	background: #FFEEEE;
+	box-shadow: 0 0 20px #B85353;
+	font-weight: bold;
+}
+</style>
+<div id="bb-alert-box">
+	<div id="bb-alert-msg"></div>
+</div>
+<div id="modal-blocker"></div>
+
+<script>
+$(function () {
+	if (!BB.hasET() && BB.getUrlParam('view') !== 'print') {
+		BB.navbar.init();
+	}
+});
+</script>
+<div id="nav-panel" class="nav-hidden-arrow hide-for-print">
+	<div id="nav-up" class="nav-btn" title="Вверх">
+		<span class="nav-icon"></span>
+	</div>
+	<div id="nav-settings" class="nav-btn">
+		<span class="nav-icon" title="Настройки"></span>
+		<ul id="nav-opt-menu">
+			<li class="nav-event" data-event="click">Показывать по клику</li>
+			<li class="nav-event" data-event="mouseenter">Показывать по наведению</li>
+		</ul>
+	</div>
+	<div id="nav-down" class="nav-btn" title="Вниз">
+		<span class="nav-icon"></span>
+	</div>
+	<div class="nav-hidden-overlay"></div>
+</div>
+
+	</div><!--/body_container-->
+
+<script>(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML="window.__CF$cv$params={r:'a1065153fdf7d5a7',t:'MTc4MjI0NzMyOQ=='};var a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);";b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script></body>
+</html>

--- a/core/network/rutracker/src/test/resources/fixtures/guest_unauthorized.html
+++ b/core/network/rutracker/src/test/resources/fixtures/guest_unauthorized.html
@@ -1,0 +1,395 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+
+<meta charset="Windows-1251">
+
+<title>rutracker.org</title>
+
+<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+<link rel="manifest" href="/manifest.json">
+<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
+<meta name="msapplication-TileColor" content="#2b5797">
+<meta name="msapplication-TileImage" content="/mstile-144x144.png">
+<meta name="theme-color" content="#ffffff">
+
+<link rel="search" type="application/opensearchdescription+xml" title="Поиск на RuTracker.org" href="https://static.rutracker.cc/opensearch.xml">
+
+<script>
+window.BB = {
+	cur_domain: location.hostname.replace(/.*?(([a-z0-9-]+\.){1,2}[a-z0-9-]+)$/, '$1'),
+	form_token: '',
+	opt_js: {},
+
+	IS_GUEST: !!'1',
+	IMG_URL: 'https://static.rutracker.cc/templates/v1/images',
+	SMILES_URL: 'https://static.rutracker.cc/smiles',
+	catId: 0,
+	FORUM_ID: 0,
+	parentForumId: 0,
+		COOKIE_MARK: 'bb_mark_read',
+	};
+BB.cookie_defaults = {
+	domain: '.' + BB.cur_domain,
+	path: "/forum/",
+};
+</script>
+<link href="https://static.rutracker.cc/templates/v1/min/eb83350bae3880e4073b81d26294de5d.all.min.css" rel="stylesheet">
+<script src="https://static.rutracker.cc/templates/v1/min/4e695e8ea9cf5a1dcc7aed231b887c51.lib.min.js"></script>
+<script src="https://static.rutracker.cc/templates/v1/min/3b60ab3546ba966484df4c3099b918ab.bb.min.js"></script>
+
+
+
+<style>
+.invisible-el {
+	/* @include element-invisible(); */
+	clip: rect(1px, 1px, 1px, 1px);
+	height: 1px;
+	overflow: hidden;
+	position: absolute !important;
+	width: 1px;
+}
+.hidden, .menu-sub, #ajax-loading, #ajax-error, var.ajax-params, #modal-blocker, .q-post {
+	display: none;
+}
+/**/
+#logo {
+	min-height: auto;
+}
+/**/
+/* temp */
+/* temp end */
+</style>
+
+<noscript>
+	<style>
+	.sp-body {
+		display: block; /* for bots */
+	}
+	</style>
+</noscript>
+
+</head>
+
+<body class="" style="">
+
+<div id="invisible-heap" class="invisible-el"></div>
+<div id="preload" class="invisible-el"></div>
+
+
+
+<div id="body_container">
+
+		<script>
+	if (top != self && !self.location.hostname.match(BB.allowed_translator_hosts)) {
+		$(function () {
+			$('body').html('<h1 style="text-align: center;"><br><br>Похоже, вас пытаются обмануть<br>frame\'s hostname: ' + self.location.hostname + '</h1>');
+			throw new Error('in frame');
+		});
+	}
+		</script>
+
+	<div id="page_container">
+
+		<div id="page_header" class="hide-for-print">
+
+			<div id="main-nav" class="site-nav clearfix">
+				<ul class="inlined middot-separated floatL">
+					<li>
+						<a href="index.php"><b>Главная</b></a>
+					</li>
+					<li>
+													<a href="tracker.php" rel="nofollow"><b>Трекер</b></a>
+											</li>
+					<li>
+						<a href="search.php" rel="nofollow"><b>Поиск</b></a>
+					</li>
+					<li>
+						<a href="groupcp.php" rel="nofollow"><b>Группы</b></a>
+					</li>
+					<li>
+						<a href="https://rutracker.wiki/" target="_blank"><b>FAQ</b></a>
+					</li>
+					<li>
+						<a href="viewtopic.php?t=6812335" style="color: #7b1fa2;"><b>VPN</b></a>
+					</li>
+					<li>
+						<a href="viewtopic.php?t=1045"><b>Правила</b></a>
+					</li>
+					<li>
+						<a href="viewtopic.php?t=6452965" style="color: #880e4f;"><b>Донаты</b></a>
+					</li>
+									</ul>
+											</div>
+			<!--/main-nav-->
+
+			
+			<div id="logo">
+				<table style="">
+				<tr>
+					<td id="logo-td" style="padding: 3px 7px 3px 15px;">
+						<a href="index.php" class="site-logo-link">
+								<img class="site-logo"
+		src="https://static.rutracker.cc/logo/logo-3.svg"
+		style=""
+		alt="logo">
+							</a>
+					</td>
+					<td class="tCenter w100" style="padding: 6px 10px 0 3px;">
+											</td>
+				</tr>
+				</table>
+			</div>
+			<!--/logo-->
+
+						<div class="topmenu">
+				<table class="w100">
+				<tr>
+					
+					<td class="tCenter pad_2 nowrap">
+						<div>
+															<a href="profile.php?mode=register" rel="nofollow"><b>Регистрация</b></a>
+								&nbsp;&#0183;&nbsp;
+								<a href="#" onclick="BB.toggle_top_login(); return false;" tabindex="5"><b>Вход</b></a>
+
+								<div id="top-login-box">
+									<form id="quick-search-guest" method="get" action="tracker.php">
+										<input id="search-text-guest" type="text" name="nm" value="" tabindex="1" accesskey="q">
+										<input type="submit" value="поиск" tabindex="2">
+									</form>
+									<form id="login-form-quick" method="post" action="login.php" style="display: none;">
+																				<input type="hidden" name="redirect" value="tracker.php?nm=ubuntu">
+																				<input id="top-login-uname" type="text" name="login_username" tabindex="1" accesskey="l" placeholder="имя">
+										<input id="top-login-pwd" type="password" name="login_password" tabindex="2" placeholder="пароль">
+										<label title="Защищенное соединение" class="login-ssl-block" style="display: none;">
+											<input class="login-ssl" type="checkbox" tabindex="3" checked>SSL
+										</label>
+										<input id="top-login-btn" type="submit" name="login" value="вход" tabindex="4">
+									</form>
+								</div>
+
+								<a href="otp.php" rel="nofollow"><b>Забыли имя или пароль?</b></a>
+													</div>
+					</td>
+
+					
+				</tr>
+				</table>
+			</div><!--/topmenu-->
+			
+			
+		</div>
+		<!--/page_header-->
+
+		
+		<div id="page_content">
+			<table style="width: 100%; border: none;">
+			<tr>
+
+				
+				<td id="main_content">
+					<div id="main_content_wrap">
+
+						
+						
+						
+						
+						<!--/page_header.tpl-->
+<script>
+$(function () {
+	var tab_idx = 100;
+	$('input,select,textarea', '#login-form-full').not(':hidden').each(function () {
+		$(this).attr({ tabindex: ++tab_idx });
+	});
+});
+</script>
+
+<h1 class="pagetitle">Вход</h1>
+
+<form id="login-form-full" action="login.php" method="post">
+
+	<input type="hidden" name="redirect" value="tracker.php?nm=ubuntu">
+
+	<p class="nav"><a href="index.php">Главная</a></p>
+
+	<table class="forumline">
+	<tr>
+		<th>Вход</th>
+	</tr>
+	<tr>
+		<td class="row1">
+
+						<h4 class="tCenter mrg_16">Введите ваше имя и пароль</h4>
+			
+			<div class="mrg_16">
+				<table class="borderless bCenter">
+				<tr>
+					<td style="width: 31%;" class="tRight">Имя:</td>
+					<td style="width: 69%;">
+						<input type="text" name="login_username" size="25" maxlength="30" value="">
+					</td>
+				</tr>
+				<tr>
+					<td class="tRight">Пароль:</td>
+					<td>
+						<input type="password" name="login_password" size="25" maxlength="32" value="">
+					</td>
+				</tr>
+								<tr class="login-ssl-block" style="display: none;">
+					<td colspan="2" class="tCenter">
+						<label><input class="login-ssl" type="checkbox" checked> Защищенное соединение</label>
+					</td>
+				</tr>
+				<tr>
+					<td colspan="2" class="tCenter pad_8">
+						<input type="submit" name="login" class="bold long" value="Вход">
+					</td>
+				</tr>
+				<tr>
+					<td colspan="2" class="tCenter med">В вашем браузере должны быть включены куки и JavaScript</td>
+				</tr>
+				</table>
+			</div>
+
+		</td>
+	</tr>
+	</table>
+
+</form>
+
+				</div><!--/main_content_wrap-->
+			</td><!--/main_content-->
+
+		</tr>
+		</table>
+	</div><!--/page_content-->
+
+	<!--page_footer-->
+	<div id="page_footer" class="hide-for-print">
+
+		
+		<div class="clear"></div>
+
+		<nav id="footer-info-links">
+			<div>
+				<a href="info.php?show=user_agreement" rel="nofollow">Условия использования</a>
+				&middot;
+				<a href="info.php?show=advert" rel="nofollow">Реклама на сайте</a>
+				&middot;
+				<a href="info.php?show=copyright_holders" rel="nofollow">Для правообладателей</a>
+				&middot;
+				<a href="info.php?show=press" rel="nofollow">Для прессы</a>
+				&middot;
+				<a href="viewtopic.php?t=2234744">Для провайдеров</a>
+				<!--&middot;-->
+				<!--<a href="http://rutracker.news">Блог</a>-->
+				&middot;
+				<a href="https://rutracker.wiki">Торрентопедия</a>
+			</div>
+			<div>
+				<a href="viewtopic.php?t=1045"><b>Правила</b></a>
+				&middot;
+				<a href="/go/8" rel="nofollow">Кому задать вопрос</a>
+				&middot;
+				<a href="viewforum.php?f=1538">Авторские раздачи</a>
+				&middot;
+				<a href="viewforum.php?f=1289">Конкурсы</a>
+				&middot;
+				<a href="viewforum.php?f=2332">Новости &quot;Хранителей&quot; и &quot;Антикваров&quot;</a>
+				&middot;
+				<a href="#" onclick="return post2url('index.php', {rand_rel: 1});" rel="nofollow">Случайная раздача</a>
+			</div>
+		</nav>
+
+		
+		<div class="tCenter nowrap" style="margin: 18px 4px 4px 4px;">
+								</div>
+
+		<div class="footer-bottom-links">
+			<ul class="inlined middot-separated">
+				<li><a href="groupcp.php?g=104792" rel="nofollow" target="_blank">Администрация</a></li>
+				<li><a href="groupcp.php?g=104787" rel="nofollow" target="_blank">Модераторы</a></li>
+				<li><a href="groupcp.php?g=104841" rel="nofollow" target="_blank">Тех. помощь</a></li>
+				<li><a href="https://t.me/rutracker_news" rel="nofollow" target="_blank">Telegram-канал</a></li>
+			</ul>
+			<div class="wide">
+									<script>
+					$(function () {
+						var title = "";
+						var src = "https://counter.yadro.ru/hit?t44.1;r" + encodeURIComponent(document.referrer) +
+							((typeof (screen) == "undefined") ? "" : ";s" + screen.width + "*" + screen.height + "*" + (screen.colorDepth ? screen.colorDepth : screen.pixelDepth)) +
+							";u" + encodeURIComponent(document.URL) + ";h" + encodeURIComponent(title.substring(0, 80)) + ";" + Math.random();
+						$('<img src="' + src + '" alt="">').on('load', function () {
+							$('#liveinternet').append(this);
+						});
+					});
+					</script>
+					<a id="liveinternet" href="https://www.liveinternet.ru/stat/rutracker.org/index.html?lang=ru" target="_blank"></a>
+							</div>
+			<ul class="inlined middot-separated">
+																							</ul>
+		</div>
+
+	</div><!--/page_footer-->
+</div><!--/page_container-->
+
+
+<div id="ajax-loading"><b>Loading...</b></div>
+<div id="ajax-error"><b>Error</b></div>
+<style>
+#bb-alert-box {
+	width: auto;
+	max-width: 800px;
+	line-height: 18px;
+	display: none;
+}
+#bb-alert-msg {
+	min-width: 400px;
+	max-height: 400px;
+	margin: 50px 20px;
+	padding: 10px;
+	overflow: auto;
+	text-align: center;
+}
+.bb-alert-err {
+	color: #7E0000;
+	background: #FFEEEE;
+	box-shadow: 0 0 20px #B85353;
+	font-weight: bold;
+}
+</style>
+<div id="bb-alert-box">
+	<div id="bb-alert-msg"></div>
+</div>
+<div id="modal-blocker"></div>
+
+<script>
+$(function () {
+	if (!BB.hasET() && BB.getUrlParam('view') !== 'print') {
+		BB.navbar.init();
+	}
+});
+</script>
+<div id="nav-panel" class="nav-hidden-arrow hide-for-print">
+	<div id="nav-up" class="nav-btn" title="Вверх">
+		<span class="nav-icon"></span>
+	</div>
+	<div id="nav-settings" class="nav-btn">
+		<span class="nav-icon" title="Настройки"></span>
+		<ul id="nav-opt-menu">
+			<li class="nav-event" data-event="click">Показывать по клику</li>
+			<li class="nav-event" data-event="mouseenter">Показывать по наведению</li>
+		</ul>
+	</div>
+	<div id="nav-down" class="nav-btn" title="Вниз">
+		<span class="nav-icon"></span>
+	</div>
+	<div class="nav-hidden-overlay"></div>
+</div>
+
+	</div><!--/body_container-->
+
+<script>(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML="window.__CF$cv$params={r:'a1065162eb93b98e',t:'MTc4MjI0NzMzMg=='};var a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);";b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script></body>
+</html>

--- a/core/network/rutracker/src/test/resources/fixtures/profile.html
+++ b/core/network/rutracker/src/test/resources/fixtures/profile.html
@@ -1,0 +1,588 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+
+<meta charset="Windows-1251">
+
+<title>filolya</title>
+
+<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+<link rel="manifest" href="/manifest.json">
+<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
+<meta name="msapplication-TileColor" content="#2b5797">
+<meta name="msapplication-TileImage" content="/mstile-144x144.png">
+<meta name="theme-color" content="#ffffff">
+
+<link rel="search" type="application/opensearchdescription+xml" title="Поиск на RuTracker.org" href="https://static.rutracker.cc/opensearch.xml">
+
+<script>
+window.BB = {
+	cur_domain: location.hostname.replace(/.*?(([a-z0-9-]+\.){1,2}[a-z0-9-]+)$/, '$1'),
+	form_token: '',
+	opt_js: {},
+
+	IS_GUEST: !!'1',
+	IMG_URL: 'https://static.rutracker.cc/templates/v1/images',
+	SMILES_URL: 'https://static.rutracker.cc/smiles',
+	catId: 0,
+	FORUM_ID: 0,
+	parentForumId: 0,
+		COOKIE_MARK: 'bb_mark_read',
+	};
+BB.cookie_defaults = {
+	domain: '.' + BB.cur_domain,
+	path: "/forum/",
+};
+</script>
+<link href="https://static.rutracker.cc/templates/v1/min/eb83350bae3880e4073b81d26294de5d.all.min.css" rel="stylesheet">
+<script src="https://static.rutracker.cc/templates/v1/min/4e695e8ea9cf5a1dcc7aed231b887c51.lib.min.js"></script>
+<script src="https://static.rutracker.cc/templates/v1/min/3b60ab3546ba966484df4c3099b918ab.bb.min.js"></script>
+
+
+
+<style>
+.invisible-el {
+	/* @include element-invisible(); */
+	clip: rect(1px, 1px, 1px, 1px);
+	height: 1px;
+	overflow: hidden;
+	position: absolute !important;
+	width: 1px;
+}
+.hidden, .menu-sub, #ajax-loading, #ajax-error, var.ajax-params, #modal-blocker, .q-post {
+	display: none;
+}
+/**/
+#logo {
+	min-height: auto;
+}
+/**/
+/* temp */
+/* temp end */
+</style>
+
+<noscript>
+	<style>
+	.sp-body {
+		display: block; /* for bots */
+	}
+	</style>
+</noscript>
+
+</head>
+
+<body class="" style="">
+
+<div id="invisible-heap" class="invisible-el"></div>
+<div id="preload" class="invisible-el"></div>
+
+
+
+<div id="body_container">
+
+		<script>
+	if (top != self && !self.location.hostname.match(BB.allowed_translator_hosts)) {
+		$(function () {
+			$('body').html('<h1 style="text-align: center;"><br><br>Похоже, вас пытаются обмануть<br>frame\'s hostname: ' + self.location.hostname + '</h1>');
+			throw new Error('in frame');
+		});
+	}
+		</script>
+
+	<div id="page_container">
+
+		<div id="page_header" class="hide-for-print">
+
+			<div id="main-nav" class="site-nav clearfix">
+				<ul class="inlined middot-separated floatL">
+					<li>
+						<a href="index.php"><b>Главная</b></a>
+					</li>
+					<li>
+													<a href="tracker.php" rel="nofollow"><b>Трекер</b></a>
+											</li>
+					<li>
+						<a href="search.php" rel="nofollow"><b>Поиск</b></a>
+					</li>
+					<li>
+						<a href="groupcp.php" rel="nofollow"><b>Группы</b></a>
+					</li>
+					<li>
+						<a href="https://rutracker.wiki/" target="_blank"><b>FAQ</b></a>
+					</li>
+					<li>
+						<a href="viewtopic.php?t=6812335" style="color: #7b1fa2;"><b>VPN</b></a>
+					</li>
+					<li>
+						<a href="viewtopic.php?t=1045"><b>Правила</b></a>
+					</li>
+					<li>
+						<a href="viewtopic.php?t=6452965" style="color: #880e4f;"><b>Донаты</b></a>
+					</li>
+									</ul>
+											</div>
+			<!--/main-nav-->
+
+			
+			<div id="logo">
+				<table style="">
+				<tr>
+					<td id="logo-td" style="padding: 3px 7px 3px 15px;">
+						<a href="index.php" class="site-logo-link">
+								<img class="site-logo"
+		src="https://static.rutracker.cc/logo/logo-3.svg"
+		style=""
+		alt="logo">
+							</a>
+					</td>
+					<td class="tCenter w100" style="padding: 6px 10px 0 3px;">
+											</td>
+				</tr>
+				</table>
+			</div>
+			<!--/logo-->
+
+						<div class="topmenu">
+				<table class="w100">
+				<tr>
+					
+					<td class="tCenter pad_2 nowrap">
+						<div>
+															<a href="profile.php?mode=register" rel="nofollow"><b>Регистрация</b></a>
+								&nbsp;&#0183;&nbsp;
+								<a href="#" onclick="BB.toggle_top_login(); return false;" tabindex="5"><b>Вход</b></a>
+
+								<div id="top-login-box">
+									<form id="quick-search-guest" method="get" action="tracker.php">
+										<input id="search-text-guest" type="text" name="nm" value="" tabindex="1" accesskey="q">
+										<input type="submit" value="поиск" tabindex="2">
+									</form>
+									<form id="login-form-quick" method="post" action="login.php" style="display: none;">
+																				<input id="top-login-uname" type="text" name="login_username" tabindex="1" accesskey="l" placeholder="имя">
+										<input id="top-login-pwd" type="password" name="login_password" tabindex="2" placeholder="пароль">
+										<label title="Защищенное соединение" class="login-ssl-block" style="display: none;">
+											<input class="login-ssl" type="checkbox" tabindex="3" checked>SSL
+										</label>
+										<input id="top-login-btn" type="submit" name="login" value="вход" tabindex="4">
+									</form>
+								</div>
+
+								<a href="otp.php" rel="nofollow"><b>Забыли имя или пароль?</b></a>
+													</div>
+					</td>
+
+					
+				</tr>
+				</table>
+			</div><!--/topmenu-->
+			
+			
+		</div>
+		<!--/page_header-->
+
+		
+		<div id="page_content">
+			<table style="width: 100%; border: none;">
+			<tr>
+
+				
+				<td id="main_content">
+					<div id="main_content_wrap">
+
+						
+						
+						
+						
+						<!--/page_header.tpl-->
+
+
+
+<style>
+#user-contacts th {
+	text-align: right;
+}
+#user-contacts td {
+	text-align: left;
+	padding: 2px 6px;
+}
+table.user_profile img {
+	vertical-align: text-bottom;
+}
+/**/
+#user-opt {
+	display: table;
+	margin: 0 auto;
+	min-width: 250px;
+}
+/**/
+#user-opt label {
+	display: block;
+	padding: 0;
+}
+#user-opt label:hover {
+	background: #D1D7DC;
+}
+#user-opt ul {
+	margin-bottom: 0;
+}
+#role span.adm, #ban-msg {
+	margin-left: 3px;
+}
+</style>
+
+<h1 class="pagetitle">
+	<span class="normal">Профиль пользователя:</span> <span id="profile-uname" class="highlight-cyrillic" data-uid="227805">filolya</span>
+	</h1>
+
+
+<div class="nav">
+	<p class="floatL">
+		<a href="index.php">Главная</a>
+	</p>
+	<div class="clear"></div>
+</div>
+
+
+<table class="user_profile bordered w100">
+<tr>
+	<th colspan="2" class="thHead">Профиль пользователя</th>
+</tr>
+<tr>
+	<td class="row1 vTop tCenter w30" style="padding: 2px 0 8px;">
+
+		<div id="avatar-img" class="mrg_4 med">
+						<img src="https://static.rutracker.cc/avatars/0/5/227805.gif" alt="avatar">											</div>
+
+				<div id="rank-img" class="mrg_6"><img class="user-rank" src="https://static.rutracker.cc/ranks/1apr_yshla_v_les.gif" alt=""></div>
+				<div class="med mrg_4">Звание:
+						<b>Ушла в лес</b>					</div>
+		
+		<h4 class="cat border bw_TB">Контакты</h4>
+
+		<div class="spacer_4"></div>
+
+		<table id="user-contacts" class="borderless wAuto bCenter">
+						<tr>
+			<th>Посл. активность:</th>
+			<td class="med" title="Посл. визит: 2026-03-10">
+				<img src="https://static.rutracker.cc/templates/v1/images/user_offline.gif" alt=""> &nbsp;2026-03-10			</td>
+		</tr>
+				<tr>
+			<th>Личное сообщ.:</th>
+			<td>
+				<ul class="inlined middot-separated">
+					<li>
+						<a class="txtb" href="privmsg.php?mode=post&amp;u=227805">Отправить</a>
+					</li>
+					<li>
+						<a class="txtb" href="privmsg.php?folder=inbox&amp;filter_uid=227805">Вход.</a>
+					</li>
+					<li>
+						<a class="txtb" href="privmsg.php?folder=sentbox&amp;filter_uid=227805">Отправл.</a>
+					</li>
+				</ul>
+			</td>
+		</tr>
+				</table><!--/user-contacts-->
+
+		<div id="user-opt">
+
+			
+		</div><!--/user-opt-->
+
+		<div class="spacer_4"></div>
+	</td>
+	<td class="row1 w70 vTop" style="padding: 2px 6px 8px;">
+
+		<div class="spacer_4"></div>
+
+		<table class="user_details borderless w100">
+								<tr>
+			<th>Стаж:</th>
+			<td>
+				<b>19 лет 9 месяцев</b>
+			</td>
+		</tr>
+		<tr>
+			<th>Зарегистрирован:</th>
+			<td>
+				<b title="">2006-09-05</b>
+							</td>
+		</tr>
+				<tr>
+			<th>Раздачи:</th>
+			<td class="med">
+				<ul class="inlined middot-separated" style="line-height: 1.8;">
+					<li>
+						<a href="tracker.php?rid=227805" class="med"><b>137</b> раздач <b> &middot; 149.98&nbsp;GB</b></a>
+					</li>
+										<li><span class="tor-icon tor-approved">&radic;</span>137 <b>&middot;</b> <b class="seedmed">149.98&nbsp;GB</b></li>
+																									<li>
+						<span
+							class="a-like"
+							title="Подписка на фиды"
+							onclick="return post2url('feed.php', {mode: 'get_feed_url', type: 'u', id: '227805'});">
+							<img class="feed-small" style="margin: 0 2px 1px 1px;" src="https://static.rutracker.cc/templates/v1/images/feed_1.png" alt="feed">
+							Подписка
+						</span>
+					</li>
+									</ul>
+			</td>
+		</tr>
+						<tr>
+			<th id="del-posts-header">Сообщения:</th>
+			<td>
+				<div id="posts">
+										<ul class="inlined middot-separated">
+						<li>
+							<a href="search.php?uid=227805&amp;search_author" class="med"><b>30,014</b> сообщений</a>
+						</li>
+						<li>
+							<a href="search.php?uid=227805&amp;search_author&amp;only_replies" class="med" title="Без заглавных сообщений">Ответы</a>
+						</li>
+						<li>
+							<a href="search.php?uid=227805&amp;myt=1" class="med topics-started">Начатые темы</a>
+						</li>
+						<li>
+							<a class="med" href="posts.php?page=replies_in_started_topics&amp;u=227805">
+								Ответы в начатых темах
+							</a>
+						</li>
+											</ul>
+									</div>
+							</td>
+		</tr>
+				<tr>
+			<th>Откуда:</th>
+			<td class="med">
+								<img src="https://static.rutracker.cc/flags/199.gif" class="poster-flag" alt="country" title="RuTracker.org">&nbsp;
+							</td>
+		</tr>
+								
+		
+		
+				<tr>
+			<th style="vertical-align: middle;">
+				Статистика отданного:
+							</th>
+			<td>
+
+								<style>
+				#traf-stats-tbl {
+					display: none;
+				}
+				</style>
+				<script>
+				$(function () {
+					$('#load-traf-stat-btn span.a-like').one('click', function () {
+						ajax.get_traf_stats();
+					});
+				});
+				ajax.get_traf_stats = function () {
+					ajax.exec({
+						action: 'get_traf_stats',
+						user_id: '227805',
+					});
+				};
+				ajax.callback.get_traf_stats = function (data) {
+					$.each(data, function (el_id) {
+						$('#' + el_id).html(data[el_id]);
+					});
+					$('#load-traf-stat-btn').remove();
+					$('#traf-stats-tbl').show();
+				};
+				</script>
+				<span id="load-traf-stat-btn" class="med">[ <span class="a-like">показать</span> ]</span>
+				
+				<table id="traf-stats-tbl" class="borderless">
+				<tr class="row3">
+					<th></th>
+					<th>Сегодня</th>
+					<th>Вчера</th>
+					<th title="Всего учтено + Сегодня">Всего</th>
+				</tr>
+				<tr class="row1">
+					<td>Отдано</td>
+					<td id="uploaded_day"><span class="editable"></span></td>
+					<td id="up_yesterday"></td>
+					<td id="uploaded_total" class="bold" title="">
+						<b class="editable" data-editable_value=""></b>
+					</td>
+				</tr>
+				<tr class="row1">
+					<td>На редких</td>
+					<td id="up_rare_day"><span class="editable"></span></td>
+					<td id="up_rare_yesterday"></td>
+					<td id="up_rare_total" class="bold" title="">
+						<b class="editable" data-editable_value=""></b>
+					</td>
+				</tr>
+				</table>
+
+			</td>
+		</tr>
+						
+		</table><!--/user_details-->
+
+				
+	</td>
+</tr>
+</table><!--/user_profile-->
+
+<div class="spacer_8"></div>
+
+<div>
+
+	
+	<h1 class="pagetitle tCenter">
+		Сидируемые раздачи:
+				<span class="normal">нет</span>
+			</h1>
+
+	
+</div>
+
+
+<!--bottom_info-->
+<div class="bottom_info">
+	<br>
+	<div class="spacer_6"></div>
+	<div class="clear"></div>
+</div><!--/bottom_info-->
+
+				</div><!--/main_content_wrap-->
+			</td><!--/main_content-->
+
+		</tr>
+		</table>
+	</div><!--/page_content-->
+
+	<!--page_footer-->
+	<div id="page_footer" class="hide-for-print">
+
+		
+		<div class="clear"></div>
+
+		<nav id="footer-info-links">
+			<div>
+				<a href="info.php?show=user_agreement" rel="nofollow">Условия использования</a>
+				&middot;
+				<a href="info.php?show=advert" rel="nofollow">Реклама на сайте</a>
+				&middot;
+				<a href="info.php?show=copyright_holders" rel="nofollow">Для правообладателей</a>
+				&middot;
+				<a href="info.php?show=press" rel="nofollow">Для прессы</a>
+				&middot;
+				<a href="viewtopic.php?t=2234744">Для провайдеров</a>
+				<!--&middot;-->
+				<!--<a href="http://rutracker.news">Блог</a>-->
+				&middot;
+				<a href="https://rutracker.wiki">Торрентопедия</a>
+			</div>
+			<div>
+				<a href="viewtopic.php?t=1045"><b>Правила</b></a>
+				&middot;
+				<a href="/go/8" rel="nofollow">Кому задать вопрос</a>
+				&middot;
+				<a href="viewforum.php?f=1538">Авторские раздачи</a>
+				&middot;
+				<a href="viewforum.php?f=1289">Конкурсы</a>
+				&middot;
+				<a href="viewforum.php?f=2332">Новости &quot;Хранителей&quot; и &quot;Антикваров&quot;</a>
+				&middot;
+				<a href="#" onclick="return post2url('index.php', {rand_rel: 1});" rel="nofollow">Случайная раздача</a>
+			</div>
+		</nav>
+
+		
+		<div class="tCenter nowrap" style="margin: 18px 4px 4px 4px;">
+								</div>
+
+		<div class="footer-bottom-links">
+			<ul class="inlined middot-separated">
+				<li><a href="groupcp.php?g=104792" rel="nofollow" target="_blank">Администрация</a></li>
+				<li><a href="groupcp.php?g=104787" rel="nofollow" target="_blank">Модераторы</a></li>
+				<li><a href="groupcp.php?g=104841" rel="nofollow" target="_blank">Тех. помощь</a></li>
+				<li><a href="https://t.me/rutracker_news" rel="nofollow" target="_blank">Telegram-канал</a></li>
+			</ul>
+			<div class="wide">
+									<script>
+					$(function () {
+						var title = "";
+						var src = "https://counter.yadro.ru/hit?t44.1;r" + encodeURIComponent(document.referrer) +
+							((typeof (screen) == "undefined") ? "" : ";s" + screen.width + "*" + screen.height + "*" + (screen.colorDepth ? screen.colorDepth : screen.pixelDepth)) +
+							";u" + encodeURIComponent(document.URL) + ";h" + encodeURIComponent(title.substring(0, 80)) + ";" + Math.random();
+						$('<img src="' + src + '" alt="">').on('load', function () {
+							$('#liveinternet').append(this);
+						});
+					});
+					</script>
+					<a id="liveinternet" href="https://www.liveinternet.ru/stat/rutracker.org/index.html?lang=ru" target="_blank"></a>
+							</div>
+			<ul class="inlined middot-separated">
+																							</ul>
+		</div>
+
+	</div><!--/page_footer-->
+</div><!--/page_container-->
+
+
+<div id="ajax-loading"><b>Loading...</b></div>
+<div id="ajax-error"><b>Error</b></div>
+<style>
+#bb-alert-box {
+	width: auto;
+	max-width: 800px;
+	line-height: 18px;
+	display: none;
+}
+#bb-alert-msg {
+	min-width: 400px;
+	max-height: 400px;
+	margin: 50px 20px;
+	padding: 10px;
+	overflow: auto;
+	text-align: center;
+}
+.bb-alert-err {
+	color: #7E0000;
+	background: #FFEEEE;
+	box-shadow: 0 0 20px #B85353;
+	font-weight: bold;
+}
+</style>
+<div id="bb-alert-box">
+	<div id="bb-alert-msg"></div>
+</div>
+<div id="modal-blocker"></div>
+
+<script>
+$(function () {
+	if (!BB.hasET() && BB.getUrlParam('view') !== 'print') {
+		BB.navbar.init();
+	}
+});
+</script>
+<div id="nav-panel" class="nav-hidden-arrow hide-for-print">
+	<div id="nav-up" class="nav-btn" title="Вверх">
+		<span class="nav-icon"></span>
+	</div>
+	<div id="nav-settings" class="nav-btn">
+		<span class="nav-icon" title="Настройки"></span>
+		<ul id="nav-opt-menu">
+			<li class="nav-event" data-event="click">Показывать по клику</li>
+			<li class="nav-event" data-event="mouseenter">Показывать по наведению</li>
+		</ul>
+	</div>
+	<div id="nav-down" class="nav-btn" title="Вниз">
+		<span class="nav-icon"></span>
+	</div>
+	<div class="nav-hidden-overlay"></div>
+</div>
+
+	</div><!--/body_container-->
+
+<script>(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML="window.__CF$cv$params={r:'a10650fe1af8910e',t:'MTc4MjI0NzMxNg=='};var a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);";b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script></body>
+</html>

--- a/core/network/rutracker/src/test/resources/fixtures/topic_not_found.html
+++ b/core/network/rutracker/src/test/resources/fixtures/topic_not_found.html
@@ -1,0 +1,354 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+
+<meta charset="Windows-1251">
+
+<title>rutracker.org</title>
+
+<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+<link rel="manifest" href="/manifest.json">
+<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
+<meta name="msapplication-TileColor" content="#2b5797">
+<meta name="msapplication-TileImage" content="/mstile-144x144.png">
+<meta name="theme-color" content="#ffffff">
+
+<link rel="search" type="application/opensearchdescription+xml" title="Поиск на RuTracker.org" href="https://static.rutracker.cc/opensearch.xml">
+
+<script>
+window.BB = {
+	cur_domain: location.hostname.replace(/.*?(([a-z0-9-]+\.){1,2}[a-z0-9-]+)$/, '$1'),
+	form_token: '',
+	opt_js: {},
+
+	IS_GUEST: !!'1',
+	IMG_URL: 'https://static.rutracker.cc/templates/v1/images',
+	SMILES_URL: 'https://static.rutracker.cc/smiles',
+	catId: 0,
+	FORUM_ID: 0,
+	parentForumId: 0,
+		COOKIE_MARK: 'bb_mark_read',
+	};
+BB.cookie_defaults = {
+	domain: '.' + BB.cur_domain,
+	path: "/forum/",
+};
+</script>
+<link href="https://static.rutracker.cc/templates/v1/min/eb83350bae3880e4073b81d26294de5d.all.min.css" rel="stylesheet">
+<script src="https://static.rutracker.cc/templates/v1/min/4e695e8ea9cf5a1dcc7aed231b887c51.lib.min.js"></script>
+<script src="https://static.rutracker.cc/templates/v1/min/3b60ab3546ba966484df4c3099b918ab.bb.min.js"></script>
+
+
+
+<style>
+.invisible-el {
+	/* @include element-invisible(); */
+	clip: rect(1px, 1px, 1px, 1px);
+	height: 1px;
+	overflow: hidden;
+	position: absolute !important;
+	width: 1px;
+}
+.hidden, .menu-sub, #ajax-loading, #ajax-error, var.ajax-params, #modal-blocker, .q-post {
+	display: none;
+}
+/**/
+#logo {
+	min-height: auto;
+}
+/**/
+/* temp */
+/* temp end */
+</style>
+
+<noscript>
+	<style>
+	.sp-body {
+		display: block; /* for bots */
+	}
+	</style>
+</noscript>
+
+</head>
+
+<body class="" style="">
+
+<div id="invisible-heap" class="invisible-el"></div>
+<div id="preload" class="invisible-el"></div>
+
+
+
+<div id="body_container">
+
+		<script>
+	if (top != self && !self.location.hostname.match(BB.allowed_translator_hosts)) {
+		$(function () {
+			$('body').html('<h1 style="text-align: center;"><br><br>Похоже, вас пытаются обмануть<br>frame\'s hostname: ' + self.location.hostname + '</h1>');
+			throw new Error('in frame');
+		});
+	}
+		</script>
+
+	<div id="page_container">
+
+		<div id="page_header" class="hide-for-print">
+
+			<div id="main-nav" class="site-nav clearfix">
+				<ul class="inlined middot-separated floatL">
+					<li>
+						<a href="index.php"><b>Главная</b></a>
+					</li>
+					<li>
+													<a href="tracker.php" rel="nofollow"><b>Трекер</b></a>
+											</li>
+					<li>
+						<a href="search.php" rel="nofollow"><b>Поиск</b></a>
+					</li>
+					<li>
+						<a href="groupcp.php" rel="nofollow"><b>Группы</b></a>
+					</li>
+					<li>
+						<a href="https://rutracker.wiki/" target="_blank"><b>FAQ</b></a>
+					</li>
+					<li>
+						<a href="viewtopic.php?t=6812335" style="color: #7b1fa2;"><b>VPN</b></a>
+					</li>
+					<li>
+						<a href="viewtopic.php?t=1045"><b>Правила</b></a>
+					</li>
+					<li>
+						<a href="viewtopic.php?t=6452965" style="color: #880e4f;"><b>Донаты</b></a>
+					</li>
+									</ul>
+											</div>
+			<!--/main-nav-->
+
+			
+			<div id="logo">
+				<table style="">
+				<tr>
+					<td id="logo-td" style="padding: 3px 7px 3px 15px;">
+						<a href="index.php" class="site-logo-link">
+								<img class="site-logo"
+		src="https://static.rutracker.cc/logo/logo-3.svg"
+		style=""
+		alt="logo">
+							</a>
+					</td>
+					<td class="tCenter w100" style="padding: 6px 10px 0 3px;">
+											</td>
+				</tr>
+				</table>
+			</div>
+			<!--/logo-->
+
+						<div class="topmenu">
+				<table class="w100">
+				<tr>
+					
+					<td class="tCenter pad_2 nowrap">
+						<div>
+															<a href="profile.php?mode=register" rel="nofollow"><b>Регистрация</b></a>
+								&nbsp;&#0183;&nbsp;
+								<a href="#" onclick="BB.toggle_top_login(); return false;" tabindex="5"><b>Вход</b></a>
+
+								<div id="top-login-box">
+									<form id="quick-search-guest" method="get" action="tracker.php">
+										<input id="search-text-guest" type="text" name="nm" value="" tabindex="1" accesskey="q">
+										<input type="submit" value="поиск" tabindex="2">
+									</form>
+									<form id="login-form-quick" method="post" action="login.php" style="display: none;">
+																				<input id="top-login-uname" type="text" name="login_username" tabindex="1" accesskey="l" placeholder="имя">
+										<input id="top-login-pwd" type="password" name="login_password" tabindex="2" placeholder="пароль">
+										<label title="Защищенное соединение" class="login-ssl-block" style="display: none;">
+											<input class="login-ssl" type="checkbox" tabindex="3" checked>SSL
+										</label>
+										<input id="top-login-btn" type="submit" name="login" value="вход" tabindex="4">
+									</form>
+								</div>
+
+								<a href="otp.php" rel="nofollow"><b>Забыли имя или пароль?</b></a>
+													</div>
+					</td>
+
+					
+				</tr>
+				</table>
+			</div><!--/topmenu-->
+			
+			
+		</div>
+		<!--/page_header-->
+
+		
+		<div id="page_content">
+			<table style="width: 100%; border: none;">
+			<tr>
+
+				
+				<td id="main_content">
+					<div id="main_content_wrap">
+
+						
+						
+						
+						
+						<!--/page_header.tpl-->
+<!--========================================================================-->
+
+<div class="spacer_10"></div>
+
+<table class="forumline message">
+<tr>
+	<th>Информация</th>
+</tr>
+<tr>
+	<td>
+				<div class="mrg_16">Тема не найдена</div>
+						<div class="mrg_12"></div>
+		<div class="mrg_12"><p class="mrg_10"><a href="index.php">Вернуться на главную</a></p></div>
+	</td>
+</tr>
+</table>
+
+<div class="spacer_10"></div>
+
+<!--========================================================================-->
+
+
+				</div><!--/main_content_wrap-->
+			</td><!--/main_content-->
+
+		</tr>
+		</table>
+	</div><!--/page_content-->
+
+	<!--page_footer-->
+	<div id="page_footer" class="hide-for-print">
+
+		
+		<div class="clear"></div>
+
+		<nav id="footer-info-links">
+			<div>
+				<a href="info.php?show=user_agreement" rel="nofollow">Условия использования</a>
+				&middot;
+				<a href="info.php?show=advert" rel="nofollow">Реклама на сайте</a>
+				&middot;
+				<a href="info.php?show=copyright_holders" rel="nofollow">Для правообладателей</a>
+				&middot;
+				<a href="info.php?show=press" rel="nofollow">Для прессы</a>
+				&middot;
+				<a href="viewtopic.php?t=2234744">Для провайдеров</a>
+				<!--&middot;-->
+				<!--<a href="http://rutracker.news">Блог</a>-->
+				&middot;
+				<a href="https://rutracker.wiki">Торрентопедия</a>
+			</div>
+			<div>
+				<a href="viewtopic.php?t=1045"><b>Правила</b></a>
+				&middot;
+				<a href="/go/8" rel="nofollow">Кому задать вопрос</a>
+				&middot;
+				<a href="viewforum.php?f=1538">Авторские раздачи</a>
+				&middot;
+				<a href="viewforum.php?f=1289">Конкурсы</a>
+				&middot;
+				<a href="viewforum.php?f=2332">Новости &quot;Хранителей&quot; и &quot;Антикваров&quot;</a>
+				&middot;
+				<a href="#" onclick="return post2url('index.php', {rand_rel: 1});" rel="nofollow">Случайная раздача</a>
+			</div>
+		</nav>
+
+		
+		<div class="tCenter nowrap" style="margin: 18px 4px 4px 4px;">
+								</div>
+
+		<div class="footer-bottom-links">
+			<ul class="inlined middot-separated">
+				<li><a href="groupcp.php?g=104792" rel="nofollow" target="_blank">Администрация</a></li>
+				<li><a href="groupcp.php?g=104787" rel="nofollow" target="_blank">Модераторы</a></li>
+				<li><a href="groupcp.php?g=104841" rel="nofollow" target="_blank">Тех. помощь</a></li>
+				<li><a href="https://t.me/rutracker_news" rel="nofollow" target="_blank">Telegram-канал</a></li>
+			</ul>
+			<div class="wide">
+									<script>
+					$(function () {
+						var title = "";
+						var src = "https://counter.yadro.ru/hit?t44.1;r" + encodeURIComponent(document.referrer) +
+							((typeof (screen) == "undefined") ? "" : ";s" + screen.width + "*" + screen.height + "*" + (screen.colorDepth ? screen.colorDepth : screen.pixelDepth)) +
+							";u" + encodeURIComponent(document.URL) + ";h" + encodeURIComponent(title.substring(0, 80)) + ";" + Math.random();
+						$('<img src="' + src + '" alt="">').on('load', function () {
+							$('#liveinternet').append(this);
+						});
+					});
+					</script>
+					<a id="liveinternet" href="https://www.liveinternet.ru/stat/rutracker.org/index.html?lang=ru" target="_blank"></a>
+							</div>
+			<ul class="inlined middot-separated">
+																							</ul>
+		</div>
+
+	</div><!--/page_footer-->
+</div><!--/page_container-->
+
+
+<div id="ajax-loading"><b>Loading...</b></div>
+<div id="ajax-error"><b>Error</b></div>
+<style>
+#bb-alert-box {
+	width: auto;
+	max-width: 800px;
+	line-height: 18px;
+	display: none;
+}
+#bb-alert-msg {
+	min-width: 400px;
+	max-height: 400px;
+	margin: 50px 20px;
+	padding: 10px;
+	overflow: auto;
+	text-align: center;
+}
+.bb-alert-err {
+	color: #7E0000;
+	background: #FFEEEE;
+	box-shadow: 0 0 20px #B85353;
+	font-weight: bold;
+}
+</style>
+<div id="bb-alert-box">
+	<div id="bb-alert-msg"></div>
+</div>
+<div id="modal-blocker"></div>
+
+<script>
+$(function () {
+	if (!BB.hasET() && BB.getUrlParam('view') !== 'print') {
+		BB.navbar.init();
+	}
+});
+</script>
+<div id="nav-panel" class="nav-hidden-arrow hide-for-print">
+	<div id="nav-up" class="nav-btn" title="Вверх">
+		<span class="nav-icon"></span>
+	</div>
+	<div id="nav-settings" class="nav-btn">
+		<span class="nav-icon" title="Настройки"></span>
+		<ul id="nav-opt-menu">
+			<li class="nav-event" data-event="click">Показывать по клику</li>
+			<li class="nav-event" data-event="mouseenter">Показывать по наведению</li>
+		</ul>
+	</div>
+	<div id="nav-down" class="nav-btn" title="Вниз">
+		<span class="nav-icon"></span>
+	</div>
+	<div class="nav-hidden-overlay"></div>
+</div>
+
+	</div><!--/body_container-->
+
+<script>(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML="window.__CF$cv$params={r:'a106514b4c1b3aba',t:'MTc4MjI0NzMyOA=='};var a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);";b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script></body>
+</html>

--- a/core/network/rutracker/src/test/resources/fixtures/topic_torrent.html
+++ b/core/network/rutracker/src/test/resources/fixtures/topic_torrent.html
@@ -1,0 +1,2298 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+
+<meta charset="Windows-1251">
+<meta name="description" content="Мандалорец и Грогу / The Mandalorian &amp; Grogu (Джон Фавро / Jon Favreau) [2026, США, фантастика, фэнтези, боевик, приключения, семейный, WEBRip] [Локализованный видеоряд] Dub (MovieDalen) &raquo; Фильмы 2026 :: RuTracker.org">
+<meta name="robots" content="nofollow">
+	<link rel="canonical" href="https://rutracker.org/forum/viewtopic.php?t=6873596">
+
+<title>Мандалорец и Грогу / The Mandalorian &amp; Grogu (Джон Фавро / Jon Favreau) [2026, США, фантастика, фэнтези, боевик, приключения, семейный, WEBRip] [Локализованный видеоряд] Dub (MovieDalen) :: RuTracker.org</title>
+
+<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+<link rel="manifest" href="/manifest.json">
+<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
+<meta name="msapplication-TileColor" content="#2b5797">
+<meta name="msapplication-TileImage" content="/mstile-144x144.png">
+<meta name="theme-color" content="#ffffff">
+
+<link rel="search" type="application/opensearchdescription+xml" title="Поиск на RuTracker.org" href="https://static.rutracker.cc/opensearch.xml">
+
+<script>
+window.BB = {
+	cur_domain: location.hostname.replace(/.*?(([a-z0-9-]+\.){1,2}[a-z0-9-]+)$/, '$1'),
+	form_token: '',
+	opt_js: {},
+
+	IS_GUEST: !!'1',
+	IMG_URL: 'https://static.rutracker.cc/templates/v1/images',
+	SMILES_URL: 'https://static.rutracker.cc/smiles',
+	catId: 2,
+	FORUM_ID: 252,
+	parentForumId: 7,
+		PG_PER_PAGE: '30',
+	PG_BASE_URL: 'viewtopic.php?t=6873596',
+		COOKIE_MARK: 'bb_mark_read',
+	};
+BB.cookie_defaults = {
+	domain: '.' + BB.cur_domain,
+	path: "/forum/",
+};
+</script>
+<link href="https://static.rutracker.cc/templates/v1/min/eb83350bae3880e4073b81d26294de5d.all.min.css" rel="stylesheet">
+<script src="https://static.rutracker.cc/templates/v1/min/4e695e8ea9cf5a1dcc7aed231b887c51.lib.min.js"></script>
+<script src="https://static.rutracker.cc/templates/v1/min/3b60ab3546ba966484df4c3099b918ab.bb.min.js"></script>
+
+
+
+<style>
+.invisible-el {
+	/* @include element-invisible(); */
+	clip: rect(1px, 1px, 1px, 1px);
+	height: 1px;
+	overflow: hidden;
+	position: absolute !important;
+	width: 1px;
+}
+.hidden, .menu-sub, #ajax-loading, #ajax-error, var.ajax-params, #modal-blocker, .q-post {
+	display: none;
+}
+/**/
+#logo {
+	min-height: auto;
+}
+/**/
+/* temp */
+/* temp end */
+</style>
+
+<noscript>
+	<style>
+	.sp-body {
+		display: block; /* for bots */
+	}
+	</style>
+</noscript>
+
+</head>
+
+<body class="" style="">
+
+<div id="invisible-heap" class="invisible-el"></div>
+<div id="preload" class="invisible-el"></div>
+
+<div class="menu-sub" id="pg-jump">
+	<table style="border-spacing: 1px;">
+	<tr>
+		<th style="padding: 2px;">К странице...</th>
+	</tr>
+	<tr>
+		<td style="padding: 2px;">
+			<form onsubmit="BB.go_to_page( $('#pg-page').val() ); return false;">
+				<input id="pg-page" type="text" size="5" maxlength="4">
+				<input type="submit" value="Перейти">
+			</form>
+		</td>
+	</tr>
+	</table>
+</div>
+
+
+<div id="body_container">
+
+		<script>
+	if (top != self && !self.location.hostname.match(BB.allowed_translator_hosts)) {
+		$(function () {
+			$('body').html('<h1 style="text-align: center;"><br><br>Похоже, вас пытаются обмануть<br>frame\'s hostname: ' + self.location.hostname + '</h1>');
+			throw new Error('in frame');
+		});
+	}
+		</script>
+
+	<div id="page_container">
+
+		<div id="page_header" class="hide-for-print">
+
+			<div id="main-nav" class="site-nav clearfix">
+				<ul class="inlined middot-separated floatL">
+					<li>
+						<a href="index.php"><b>Главная</b></a>
+					</li>
+					<li>
+													<a href="tracker.php" rel="nofollow"><b>Трекер</b></a>
+											</li>
+					<li>
+						<a href="search.php" rel="nofollow"><b>Поиск</b></a>
+					</li>
+					<li>
+						<a href="groupcp.php" rel="nofollow"><b>Группы</b></a>
+					</li>
+					<li>
+						<a href="https://rutracker.wiki/" target="_blank"><b>FAQ</b></a>
+					</li>
+					<li>
+						<a href="viewtopic.php?t=6812335" style="color: #7b1fa2;"><b>VPN</b></a>
+					</li>
+					<li>
+						<a href="viewtopic.php?t=1045"><b>Правила</b></a>
+					</li>
+					<li>
+						<a href="viewtopic.php?t=6452965" style="color: #880e4f;"><b>Донаты</b></a>
+					</li>
+									</ul>
+											</div>
+			<!--/main-nav-->
+
+			
+			<div id="logo">
+				<table style="">
+				<tr>
+					<td id="logo-td" style="padding: 3px 7px 3px 15px;">
+						<a href="index.php" class="site-logo-link">
+								<img class="site-logo"
+		src="https://static.rutracker.cc/logo/logo-3.svg"
+		style=""
+		alt="logo">
+							</a>
+					</td>
+					<td class="tCenter w100" style="padding: 6px 10px 0 3px;">
+											</td>
+				</tr>
+				</table>
+			</div>
+			<!--/logo-->
+
+						<div class="topmenu">
+				<table class="w100">
+				<tr>
+					
+					<td class="tCenter pad_2 nowrap">
+						<div>
+															<a href="profile.php?mode=register" rel="nofollow"><b>Регистрация</b></a>
+								&nbsp;&#0183;&nbsp;
+								<a href="#" onclick="BB.toggle_top_login(); return false;" tabindex="5"><b>Вход</b></a>
+
+								<div id="top-login-box">
+									<form id="quick-search-guest" method="get" action="tracker.php">
+										<input id="search-text-guest" type="text" name="nm" value="" tabindex="1" accesskey="q">
+										<input type="submit" value="поиск" tabindex="2">
+									</form>
+									<form id="login-form-quick" method="post" action="login.php" style="display: none;">
+																				<input id="top-login-uname" type="text" name="login_username" tabindex="1" accesskey="l" placeholder="имя">
+										<input id="top-login-pwd" type="password" name="login_password" tabindex="2" placeholder="пароль">
+										<label title="Защищенное соединение" class="login-ssl-block" style="display: none;">
+											<input class="login-ssl" type="checkbox" tabindex="3" checked>SSL
+										</label>
+										<input id="top-login-btn" type="submit" name="login" value="вход" tabindex="4">
+									</form>
+								</div>
+
+								<a href="otp.php" rel="nofollow"><b>Забыли имя или пароль?</b></a>
+													</div>
+					</td>
+
+					
+				</tr>
+				</table>
+			</div><!--/topmenu-->
+			
+			
+		</div>
+		<!--/page_header-->
+
+		
+		<div id="page_content">
+			<table style="width: 100%; border: none;">
+			<tr>
+
+				
+				<td id="main_content">
+					<div id="main_content_wrap">
+
+						
+						
+						
+						
+						<!--/page_header.tpl-->
+
+
+<script>
+$(function () {
+		BB.initMagnetLinks();
+	});
+</script>
+
+
+
+
+<table class="w100">
+<tr>
+	<td class="w100 vBottom pad_2">
+		<h1 class="maintitle">
+			<a id="topic-title" class="topic-title-6873596 highlight-cyrillic" href="https://rutracker.org/forum/viewtopic.php?t=6873596">Мандалорец и Грогу / The Mandalorian &amp; Grogu (Джон Фавро / Jon Favreau) [2026, США, фантастика, фэнтези, боевик, приключения,<wbr> семейный, WEBRip] [Локализованн<wbr>ый видеоряд] Dub (MovieDalen)<wbr></a>
+		</h1>
+		<div class="small hide-for-print" style="margin: 12px 4px 8px;">
+			<b><span class="pg-jump-menu"><a class="menu-root" href="#pg-jump" onclick="BB.focus_pg_input();">Страницы</a> :&nbsp;&nbsp;</span><b>1</b>, <a class="pg" href="viewtopic.php?t=6873596&amp;start=30">2</a>&nbsp;&nbsp;<a class="pg" href="viewtopic.php?t=6873596&amp;start=30">След.</a></b>
+		</div>
+		
+		<table class="w100">
+		<tr>
+			<td class="pad_2 hide-for-print">
+				<a href="posting.php?mode=reply&amp;t=6873596"><img src="https://static.rutracker.cc/templates/v1/images/reply.gif" alt="Ответить"></a>
+			</td>
+			<td class="nav t-breadcrumb-top w100 pad_2">
+				&nbsp;<a href="index.php?c=2">Кино, Видео и ТВ</a>
+								<em>&raquo;</em> <a href="viewforum.php?f=7">Зарубежное кино</a>
+								<em>&raquo;</em> <a href="viewforum.php?f=252">Фильмы 2026</a>
+			</td>
+		</tr>
+		</table>
+
+	</td>
+	<td class="pad_2 hide-for-print">
+			</td>
+</tr>
+</table>
+
+
+
+
+
+<table class="topic" id="topic_main">
+<tbody class="hide-for-print">
+<tr>
+	<th colspan="2" class="thHead">
+		<div id="soc-container" data-share_url="https://rutracker.org/forum/viewtopic.php?t=6873596" data-share_title="Мандалорец и Грогу / The Mandalorian &amp; Grogu (Джон Фавро / Jon Favreau) [2026, США, фантастика, фэнтези, боевик, приключения, семейный, WEBRip] [Локализованный видеоряд] Dub (MovieDalen)">&nbsp;</div>
+	</th>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89299512" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89299512"></a>
+		
+		
+				<p class="nick nick-author">порошков</p>
+		
+		
+				<p class="rank_img"><img class="user-rank" src="https://static.rutracker.cc/ranks/s_mod.gif" alt="Moderator"></p>		<p class="avatar"><img src="https://static.rutracker.cc/avatars/1/1/8679101.png" alt=""></p>		<p class="joined"><em>Стаж:</em> 17 лет 4 месяца</p>		<p class="posts"><em>Сообщений:</em> 26743</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">порошков &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?t=6873596">22-Июн-26 04:19</a>
+				</span>
+												<span class="posted_since hide-for-print">(1 день 19 часов назад)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+								
+				
+																											</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-1">
+												<div class="post_body" id="p-89299512" data-ext_link_data='{"p":89299512,"t":6873596,"f":252,"u":8679101}'>
+													<span style="font-size: 24px; line-height: normal;"><span class="post-b"><span class="post-u">Мандалорец и Грогу / The Mandalorian &amp; Grogu</span></span></span><span class="post-br"><br></span><var class="postImg postImgAligned img-right" title="https://i6.imageban.ru/out/2026/06/22/422699cc36b18bc4ae051d1b083630d4.jpg">&#10;</var><span class="post-font-serif1"><span style="font-size: 15px; line-height: normal;"><span class="post-b">Страна</span>: США<br>
+<span class="post-b">Жанр</span>: фантастика, фэнтези, боевик, приключения, семейный<br>
+<span class="post-b">Год выпуска</span>: 2026<br>
+<span class="post-b">Продолжительность</span>: 02:11:55<hr class="post-hr"><span class="post-b">Перевод</span>: Профессиональный (дублированный) | <span class="post-b"><span class="p-color" style="color: darkred;">MovieDalen</span></span><br>
+<span class="post-b">Субтитры</span>: русские (forced - hardsub)<br>
+<span class="post-b">Оригинальная аудиодорожка</span>: нет<hr class="post-hr"><span class="post-b">Режиссер</span>:<br>
+Джон Фавро / Jon Favreau<hr class="post-hr"><span class="post-b">В ролях</span>: Педро Паскаль, Джереми Аллен Уайт, Стивен Блум, Сигурни Уивер, Брендан Уэйн, Латиф Кроудер, Джонатан Койн, Мэттью Уиллиг<hr class="post-hr"><span class="post-b">Описание</span>: Империя пала, но её военачальники всё ещё держат под своим контролем части галактики. Зарождающаяся Новая Республика пытается защитить идеалы, за которые сражались повстанцы, и нанимает для задания мандалорца Дина Джарина, известного охотника за головами, и его юного ученика Грогу.<hr class="post-hr"><a href="https://www.kinopoisk.ru/film/5437088/" class="postLink"><var class="postImg" title="https://rating.kinopoisk.ru/5437088.gif">&#10;</var></a><hr class="post-hr"><span class="post-b">Качество видео</span>: WEBRip<br>
+<span class="post-b">Формат видео</span>: AVI<span class="post-br"><br></span><span class="post-b">Видео</span>: 720x304 (2.37:1), 24.000 fps, XviD build 73 ~1377 kbps avg, 0.26 bit/pixel<br>
+<span class="post-b">Аудио</span>: 48 kHz, AC3 Dolby Digital, 2/0 (L,R) ch, ~192 kbps<hr class="post-hr"></span></span>
+<div class="post-box-default">
+<div class="post-box"><span class="post-b"><a href="https://cloud.mail.ru/public/2a6L/UmptPcziP" class="postLink">Сэмпл</a></span></div>
+</div>
+<hr class="post-hr">
+<div class="sp-wrap">
+<div class="sp-head folded"><span>MediaInfo</span></div>
+<div class="sp-body">
+<pre class="post-pre"></pre>
+<div class="c-wrap">
+<div class="c-head"><b>Код:</b></div>
+<div class="c-body"><br>
+Формат&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; AVI<br>
+Формат/Информация&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; Audio Video Interleave<br>
+Настройки формата&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; BitmapInfoHeader / WaveFormatEx<br>
+Размер файла&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; 1,46 Гбайт<br>
+Продолжительность&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; 2 ч. 11 м.<br>
+Общий битрейт&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; 1 579 Кбит/сек<br>
+Частота кадров&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; 24,000 кадра/сек<br>
+Заголовок&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; Мандалорец и Грогу_2026_WEBRip<br>
+Программа кодирования&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; VirtualDubMod 1.5.10.3 | www.virtualdub-fr.org || (build 2550/release&#41;<br>
+Авторское право&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; порошков<span class="post-br"><br></span>Видео<br>
+Идентификатор&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; 0<br>
+Формат&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; MPEG-4 Visual<br>
+Профиль формата&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; Advanced Simple@L5<br>
+Настройки формата&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; BVOP1 / Custom Matrix<br>
+Параметр BVOP формата&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; 1<br>
+Параметр QPel формата&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; Нет<br>
+Параметр GMC формата&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; Без точки перехода<br>
+Параметр Matrix формата&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; Выборочная<br>
+Идентификатор кодека&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; XVID<br>
+Идентификатор кодека/Подсказка&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; XviD<br>
+Продолжительность&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; 2 ч. 11 м.<br>
+Битрейт&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; 1 378 Кбит/сек<br>
+Ширина&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; 720 пикселей<br>
+Высота&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; 304 пикселя<br>
+Соотношение сторон&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; 2,35&#58;1<br>
+Частота кадров&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; 24,000 кадра/сек<br>
+Цветовое пространство&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; YUV<br>
+Цветовая субдискретизация&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; 4&#58;2&#58;0<br>
+Битовая глубина&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; 8 бит<br>
+Тип развёртки&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; Прогрессивная<br>
+Метод сжатия&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; С потерями<br>
+Бит/(Пиксели*Кадры&#41;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; 0.262<br>
+Размер потока&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; 1,27 Гбайт (87%&#41;<br>
+Библиотека кодирования&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; XviD 73<span class="post-br"><br></span>Аудио<br>
+Идентификатор&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; 1<br>
+Формат&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; AC-3<br>
+Формат/Информация&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; Audio Coding 3<br>
+Коммерческое название&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; Dolby Digital<br>
+Идентификатор кодека&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; 2000<br>
+Продолжительность&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; 2 ч. 11 м.<br>
+Вид битрейта&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; Постоянный<br>
+Битрейт&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; 192 Кбит/сек<br>
+Каналы&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; 2 канала<br>
+Расположение каналов&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; L R<br>
+Частота дискретизации&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; 48,0 КГц<br>
+Частота кадров&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; 31,250 кадров/сек (1536 SPF&#41;<br>
+Метод сжатия&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; С потерями<br>
+Размер потока&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; 181 Мбайт (12%&#41;<br>
+Выравнивание&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; Разделение по промежуткам<br>
+Чередование, продолжительность&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; 42&nbsp; мс. (1,00 видеокадр&#41;<br>
+Чередование, продолжительность предзагру &#58; 500&nbsp; мс.<br>
+Вид сервиса&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; Complete Main<br>
+Нормализация звука речи&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; -15 dB<br>
+compr&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; -0.28 dB<br>
+ltrtcmixlev&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; -3.0 dB<br>
+ltrtsurmixlev&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; -3.0 dB<br>
+lorocmixlev&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; -3.0 dB<br>
+lorosurmixlev&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; -3.0 dB<br>
+Нормализация звука речи, среднее&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; -15 dB<br>
+Нормализация звука речи, минимум&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; -15 dB<br>
+Нормализация звука речи, максимум&nbsp; &nbsp; &nbsp; &nbsp; &#58; -15 dB<br></div>
+</div>
+</div>
+</div>
+<div class="sp-wrap">
+<div class="sp-head folded"><span>Скриншоты</span></div>
+<div class="sp-body"><a href="https://imageban.ru/show/2026/06/22/4431dbf17fe1a390f3feab062cc337fb/png" class="postLink"><var class="postImg" title="https://i3.imageban.ru/thumbs/2026.06.22/4431dbf17fe1a390f3feab062cc337fb.png">&#10;</var></a><a href="https://imageban.ru/show/2026/06/22/ce311500a323ba0998e09c7e06f8ebdc/png" class="postLink"><var class="postImg" title="https://i5.imageban.ru/thumbs/2026.06.22/ce311500a323ba0998e09c7e06f8ebdc.png">&#10;</var></a><a href="https://imageban.ru/show/2026/06/22/a1ceb01fd8c9b9f0b4efbebd2621393a/png" class="postLink"><var class="postImg" title="https://i7.imageban.ru/thumbs/2026.06.22/a1ceb01fd8c9b9f0b4efbebd2621393a.png">&#10;</var></a><a href="https://imageban.ru/show/2026/06/22/034d98c8a23d79d3e2c1aac6f9aef0f6/png" class="postLink"><var class="postImg" title="https://i1.imageban.ru/thumbs/2026.06.22/034d98c8a23d79d3e2c1aac6f9aef0f6.png">&#10;</var></a><br>
+<a href="https://imageban.ru/show/2026/06/22/b5dc017248020a09ea7a109003f70eeb/png" class="postLink"><var class="postImg" title="https://i8.imageban.ru/thumbs/2026.06.22/b5dc017248020a09ea7a109003f70eeb.png">&#10;</var></a><a href="https://imageban.ru/show/2026/06/22/b6a47c18c95f7bda11e2d6657665b892/png" class="postLink"><var class="postImg" title="https://i1.imageban.ru/thumbs/2026.06.22/b6a47c18c95f7bda11e2d6657665b892.png">&#10;</var></a><a href="https://imageban.ru/show/2026/06/22/82a72844129438af94314ea19d2430e1/png" class="postLink"><var class="postImg" title="https://i5.imageban.ru/thumbs/2026.06.22/82a72844129438af94314ea19d2430e1.png">&#10;</var></a><a href="https://imageban.ru/show/2026/06/22/8e98f17428e4f838a62378b3f3ac2f71/png" class="postLink"><var class="postImg" title="https://i4.imageban.ru/thumbs/2026.06.22/8e98f17428e4f838a62378b3f3ac2f71.png">&#10;</var></a></div>
+</div>
+<span class="post-align" style="text-align: center;"><span class="post-font-serif1"><span style="font-size: 16px; line-height: normal;"><span class="post-b">При выходе лучшего качаества раздачу обновлю.</span></span></span></span>											</div><!--/post_body-->
+
+			
+			<div class="clear" style="height: 8px;"></div>
+
+			
+			
+			<fieldset class="attach">
+				<legend>Download</legend>
+								<div class="attach_link guest">
+					<ul class="inlined middot-separated">
+						<li>
+							<a href="magnet:?xt=urn:btih:E53DA7E8D44BD5016BF8074A0E8A49CA0EE7EE17&tr=http%3A%2F%2Fbt4.t-ru.org%2Fann%3Fmagnet" class="magnet-link" data-topic_id="6873596" >
+								<img src="https://static.rutracker.cc/templates/v1/images/magnet_1.svg" alt="">Скачать по magnet-ссылке</a>
+						</li>
+												<li>1.46&nbsp;GB</li>
+					</ul>
+				</div>
+												<div class="attachment-disclaimer">
+					Rutracker.org не распространяет и не хранит электронные версии произведений, а лишь предоставляет доступ к создаваемому
+					пользователями каталогу ссылок на <a href="https://ru.wikipedia.org/wiki/BitTorrent" target="_blank">торрент-файлы</a>,
+					которые содержат только списки хеш-сумм
+				</div>
+				<div class="attachment-disclaimer">
+					<a href="/go/1" target="_blank"><b>Как скачивать?</b></a>
+					<i>(для скачивания <b>.torrent</b> файлов необходима
+						<a href="profile.php?mode=register" target="_blank"><b>регистрация</b></a>)</i>
+				</div>
+			</fieldset>
+
+			
+			
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=8679101">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=8679101">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89299549" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89299549"></a>
+		
+		
+				<p class="nick ">Dark_ReN</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/4/24/20627024.png" alt=""></p>		<p class="joined"><em>Стаж:</em> 15 лет 6 месяцев</p>		<p class="posts"><em>Сообщений:</em> 1310</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">Dark_ReN &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89299549#89299549">22-Июн-26 05:17</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 58 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89299549">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-2">
+						<div class="post_body" id="p-89299549" data-ext_link_data='{"p":89299549,"t":6873596,"f":252,"u":20627024}'>
+													афигенчик, я лично в восторге! ясно, что марвелщина/5 класс, но это не нудный сериал, оно бодро и динамично, а графон, сама картинка, столько ярких деталей, такие виды, юморок, вообще.. отлично, имхо 8.5/10											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=20627024">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=20627024">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89299596" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89299596"></a>
+		
+		
+				<p class="nick ">13stakanoff</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/2/94/13788994.jpg" alt=""></p>		<p class="joined"><em>Стаж:</em> 16 лет 6 месяцев</p>		<p class="posts"><em>Сообщений:</em> 45</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">13stakanoff &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89299596#89299596">22-Июн-26 06:18</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 1 час)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89299596">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-3">
+						<div class="post_body" id="p-89299596" data-ext_link_data='{"p":89299596,"t":6873596,"f":252,"u":13788994}'>
+													Спасибо за труды											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=13788994">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=13788994">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89299668" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89299668"></a>
+		
+		
+				<p class="nick ">apleon</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/4/81/24588081.jpg" alt=""></p>		<p class="joined"><em>Стаж:</em> 14 лет 6 месяцев</p>		<p class="posts"><em>Сообщений:</em> 1222</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">apleon &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89299668#89299668">22-Июн-26 07:16</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 57 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89299668">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-4">
+						<div class="post_body" id="p-89299668" data-ext_link_data='{"p":89299668,"t":6873596,"f":252,"u":24588081}'>
+													Педро Паскаль в роли Джаббы? Надо подождать лучшего качества,											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=24588081">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=24588081">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89299827" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89299827"></a>
+		
+		
+				<p class="nick ">aida1970</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/2/3/10883403.jpg" alt=""></p>		<p class="joined"><em>Стаж:</em> 16 лет 11 месяцев</p>		<p class="posts"><em>Сообщений:</em> 13</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">aida1970 &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89299827#89299827">22-Июн-26 08:59</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 1 час 43 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89299827">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-5">
+						<div class="post_body" id="p-89299827" data-ext_link_data='{"p":89299827,"t":6873596,"f":252,"u":10883403}'>
+													манда ? кто в роли манды, не СИГУРНИ УИВЕР?											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=10883403">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=10883403">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89299960" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89299960"></a>
+		
+		
+				<p class="nick ">Шпил</p>
+		
+		
+								<p class="joined"><em>Стаж:</em> 3 месяца 20 дней</p>		<p class="posts"><em>Сообщений:</em> 15</p>		
+		
+		<br>	</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">Шпил &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89299960#89299960">22-Июн-26 10:07</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 1 час 7 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89299960">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-6">
+						<div class="post_body" id="p-89299960" data-ext_link_data='{"p":89299960,"t":6873596,"f":252,"u":54695927}'>
+													Спасибо, забираем !											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=54695927">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=54695927">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89300081" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89300081"></a>
+		
+		
+				<p class="nick ">apleon</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/4/81/24588081.jpg" alt=""></p>		<p class="joined"><em>Стаж:</em> 14 лет 6 месяцев</p>		<p class="posts"><em>Сообщений:</em> 1222</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">apleon &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89300081#89300081">22-Июн-26 11:07</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 1 час)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89300081">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-7">
+						<div class="post_body" id="p-89300081" data-ext_link_data='{"p":89300081,"t":6873596,"f":252,"u":24588081}'>
+													Cигурни полковницу играет, согласно локализаторам <img class="smile" src="https://static.rutracker.cc/smiles/icon_lol.gif" alt=""><br>
+Фильм очень хорошо зашёл в кинотеатре.											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=24588081">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=24588081">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89300141" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89300141"></a>
+		
+		
+				<p class="nick ">Dzherelo</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/9/99/49789099.jpg" alt=""></p>		<p class="joined"><em>Стаж:</em> 3 года 4 месяца</p>		<p class="posts"><em>Сообщений:</em> 129</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">Dzherelo &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89300141#89300141">22-Июн-26 11:32</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 24 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89300141">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-8">
+						<div class="post_body" id="p-89300141" data-ext_link_data='{"p":89300141,"t":6873596,"f":252,"u":49789099}'>
+													Как это говно 7 баллов набирает на КП и ИМДБ? Оно еще не окупилось даже (и уже вряд ли окупится).											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=49789099">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=49789099">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89300340" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89300340"></a>
+		
+		
+				<p class="nick ">proWin цэ ALL</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/9/47/49558547.jpg" alt=""></p>		<p class="joined"><em>Стаж:</em> 3 года 6 месяцев</p>		<p class="posts"><em>Сообщений:</em> 1330</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">proWin цэ ALL &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89300340#89300340">22-Июн-26 13:01</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 1 час 29 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89300340">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-9">
+						<div class="post_body" id="p-89300340" data-ext_link_data='{"p":89300340,"t":6873596,"f":252,"u":49558547}'>
+													<div class="q-wrap">
+<div class="q-head"><span><b>Dzherelo</b> писал(а):</span></div>
+<div class="q"><u class="q-post">89300141</u>Как это говно 7 баллов набирает</div>
+</div>
+фанты'c											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=49558547">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=49558547">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89300954" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89300954"></a>
+		
+		
+				<p class="nick ">Andrew_ma</p>
+		
+		
+								<p class="joined"><em>Стаж:</em> 17 лет 4 месяца</p>		<p class="posts"><em>Сообщений:</em> 21</p>		
+		
+		<br>	</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">Andrew_ma &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89300954#89300954">22-Июн-26 17:21</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 4 часа)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89300954">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-10">
+						<div class="post_body" id="p-89300954" data-ext_link_data='{"p":89300954,"t":6873596,"f":252,"u":8279888}'>
+													RIP StarWars... its a shit, not movie...											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=8279888">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=8279888">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89301076" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89301076"></a>
+		
+		
+				<p class="nick ">Snon</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/4/12/20217412.jpg" alt=""></p>		<p class="joined"><em>Стаж:</em> 15 лет 7 месяцев</p>		<p class="posts"><em>Сообщений:</em> 314</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">Snon &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89301076#89301076">22-Июн-26 18:04</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 43 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89301076">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-11">
+						<div class="post_body" id="p-89301076" data-ext_link_data='{"p":89301076,"t":6873596,"f":252,"u":20217412}'>
+													Педро и бокал грога.											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=20217412">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=20217412">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89301160" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89301160"></a>
+		
+		
+				<p class="nick ">kirikov8080</p>
+		
+		
+								<p class="joined"><em>Стаж:</em> 16 лет 6 месяцев</p>		<p class="posts"><em>Сообщений:</em> 345</p>		
+		
+		<br>	</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">kirikov8080 &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89301160#89301160">22-Июн-26 18:31</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 26 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89301160">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-12">
+						<div class="post_body" id="p-89301160" data-ext_link_data='{"p":89301160,"t":6873596,"f":252,"u":14066340}'>
+													Очень хотелось попереживать за главных героев, но они не дали ни единого шанса...											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=14066340">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=14066340">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89301187" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89301187"></a>
+		
+		
+				<p class="nick ">apleon</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/4/81/24588081.jpg" alt=""></p>		<p class="joined"><em>Стаж:</em> 14 лет 6 месяцев</p>		<p class="posts"><em>Сообщений:</em> 1222</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">apleon &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89301187#89301187">22-Июн-26 18:44</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 12 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89301187">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-13">
+						<div class="post_body" id="p-89301187" data-ext_link_data='{"p":89301187,"t":6873596,"f":252,"u":24588081}'>
+													<div class="q-wrap">
+<div class="q-head"><span><b>kirikov8080</b> писал(а):</span></div>
+<div class="q"><u class="q-post">89301160</u>Очень хотелось попереживать за главных героев, но они не дали ни единого шанса...</div>
+</div>
+Там не за кого переживать											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=24588081">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=24588081">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89301194" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89301194"></a>
+		
+		
+				<p class="nick ">Semperdun</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/7/52/36271252.jpg" alt=""></p>		<p class="joined"><em>Стаж:</em> 11 лет 11 месяцев</p>		<p class="posts"><em>Сообщений:</em> 133</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">Semperdun &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89301194#89301194">22-Июн-26 18:45</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 1 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89301194">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-14">
+						<div class="post_body" id="p-89301194" data-ext_link_data='{"p":89301194,"t":6873596,"f":252,"u":36271252}'>
+													Гаврила хейтил Мандалорца, Гаврила лорца отрицал											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=36271252">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=36271252">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89301209" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89301209"></a>
+		
+		
+				<p class="nick ">nevesom-8</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/4/78/24121078.jpg" alt=""></p>		<p class="joined"><em>Стаж:</em> 14 лет 7 месяцев</p>		<p class="posts"><em>Сообщений:</em> 158</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">nevesom-8 &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89301209#89301209">22-Июн-26 18:49</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 4 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89301209">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-15">
+						<div class="post_body" id="p-89301209" data-ext_link_data='{"p":89301209,"t":6873596,"f":252,"u":24121078}'>
+													Kung Lao - самый лучший перс!!!											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=24121078">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=24121078">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89301239" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89301239"></a>
+		
+		
+				<p class="nick ">waltage80</p>
+		
+		
+								<p class="joined"><em>Стаж:</em> 6 лет 1 месяц</p>		<p class="posts"><em>Сообщений:</em> 126</p>		
+		
+		<br>	</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">waltage80 &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89301239#89301239">22-Июн-26 18:59</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 9 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89301239">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-16">
+						<div class="post_body" id="p-89301239" data-ext_link_data='{"p":89301239,"t":6873596,"f":252,"u":45375146}'>
+													локализованный видеоряд Диснеевского кино это говно из говна<br>
+говно в квадрате											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=45375146">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=45375146">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89301280" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89301280"></a>
+		
+		
+				<p class="nick ">Redbear01</p>
+		
+		
+								<p class="joined"><em>Стаж:</em> 16 лет 3 месяца</p>		<p class="posts"><em>Сообщений:</em> 6</p>		
+		
+		<br>	</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">Redbear01 &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89301280#89301280">22-Июн-26 19:16</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 16 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89301280">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-17">
+						<div class="post_body" id="p-89301280" data-ext_link_data='{"p":89301280,"t":6873596,"f":252,"u":15766482}'>
+													Объясните пожалуйста. Ведь стриминги вещают до 4K разрешением, почему этот WEBRip такое лютое говнище? На видеомагнитофон как-то записывают или я что-то не понимаю											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=15766482">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=15766482">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89301358" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89301358"></a>
+		
+		
+				<p class="nick ">Nordwind 65</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/10/20/50995220.jpg" alt=""></p>		<p class="joined"><em>Стаж:</em> 2 года 7 месяцев</p>		<p class="posts"><em>Сообщений:</em> 142</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">Nordwind 65 &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89301358#89301358">22-Июн-26 19:48</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 31 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89301358">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-18">
+						<div class="post_body" id="p-89301358" data-ext_link_data='{"p":89301358,"t":6873596,"f":252,"u":50995220}'>
+													Звук, отстой, 2,0. Вилы.<br>
+Оригинальную дорогу положили, хотя бы, в 5,1, сделал бы многоканалку.<br>
+Тьфу, едрён-батом ети их подери.											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=50995220">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=50995220">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89301495" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89301495"></a>
+		
+		
+				<p class="nick ">russvarg</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/1/37/9413537.png" alt=""></p>		<p class="joined"><em>Стаж:</em> 17 лет 2 месяца</p>		<p class="posts"><em>Сообщений:</em> 178</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">russvarg &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89301495#89301495">22-Июн-26 20:37</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 49 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89301495">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-19">
+						<div class="post_body" id="p-89301495" data-ext_link_data='{"p":89301495,"t":6873596,"f":252,"u":9413537}'>
+													Те кто называет фильм говном его не смотрели или просто фанаты советских фильмов.											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=9413537">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=9413537">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89301545" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89301545"></a>
+		
+		
+				<p class="nick ">Doctor-ZLO</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/9/53/47433553.jpg" alt=""></p>		<p class="joined"><em>Стаж:</em> 4 года 7 месяцев</p>		<p class="posts"><em>Сообщений:</em> 96</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">Doctor-ZLO &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89301545#89301545">22-Июн-26 20:57</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 20 мин., ред. 22-Июн-26 20:57)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89301545">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-20">
+						<div class="post_body" id="p-89301545" data-ext_link_data='{"p":89301545,"t":6873596,"f":252,"u":47433553}'>
+													Отличный фильм, тока не понравилась музыкальное сопровождение. Ну не то совсем. Классический оркестр как в старых эпизодах был бы крут.											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=47433553">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=47433553">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89301576" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89301576"></a>
+		
+		
+				<p class="nick ">R.Richter</p>
+		
+		
+								<p class="joined"><em>Стаж:</em> 11 месяцев</p>		<p class="posts"><em>Сообщений:</em> 123</p>		
+		
+		<br>	</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">R.Richter &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89301576#89301576">22-Июн-26 21:09</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 12 мин., ред. 22-Июн-26 21:09)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89301576">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-21">
+						<div class="post_body" id="p-89301576" data-ext_link_data='{"p":89301576,"t":6873596,"f":252,"u":53582853}'>
+													<div class="q-wrap">
+<div class="q-head"><span><b>russvarg</b> писал(а):</span></div>
+<div class="q"><u class="q-post">89301495</u>Те кто называет фильм говном его не смотрели или просто фанаты советских фильмов.</div>
+</div>
+Если фанаты советских фильмов называют фильм говном, значит фильм говно.											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=53582853">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=53582853">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89301635" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89301635"></a>
+		
+		
+				<p class="nick ">mr.chonkin</p>
+		
+		
+								<p class="joined"><em>Стаж:</em> 13 лет 11 месяцев</p>		<p class="posts"><em>Сообщений:</em> 92</p>		
+		
+		<br>	</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">mr.chonkin &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89301635#89301635">22-Июн-26 21:28</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 18 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89301635">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-22">
+						<div class="post_body" id="p-89301635" data-ext_link_data='{"p":89301635,"t":6873596,"f":252,"u":27806245}'>
+													Сигурни Вывернет Матильду											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=27806245">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=27806245">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89301732" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89301732"></a>
+		
+		
+				<p class="nick ">vatanabi</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/3/16/15367716.jpg" alt=""></p>		<p class="joined"><em>Стаж:</em> 16 лет 4 месяца</p>		<p class="posts"><em>Сообщений:</em> 551</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">vatanabi &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89301732#89301732">22-Июн-26 22:03</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 35 мин., ред. 22-Июн-26 22:03)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89301732">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-23">
+						<div class="post_body" id="p-89301732" data-ext_link_data='{"p":89301732,"t":6873596,"f":252,"u":15367716}'>
+													Тяжело в шлеме ходить.. <img class="smile" src="https://static.rutracker.cc/smiles/icon_biggrin.gif" alt="">											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=15367716">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=15367716">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89301997" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89301997"></a>
+		
+		
+				<p class="nick ">g n</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/1/35/5755235.jpg" alt=""></p>		<p class="joined"><em>Стаж:</em> 17 лет 8 месяцев</p>		<p class="posts"><em>Сообщений:</em> 7</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">g n &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89301997#89301997">22-Июн-26 23:50</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 1 час 47 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89301997">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-24">
+						<div class="post_body" id="p-89301997" data-ext_link_data='{"p":89301997,"t":6873596,"f":252,"u":5755235}'>
+													херова.. гл героя зовут манда											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=5755235">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=5755235">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89302112" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89302112"></a>
+		
+		
+				<p class="nick ">mentalrisk2</p>
+		
+		
+								<p class="joined"><em>Стаж:</em> 14 лет 6 месяцев</p>		<p class="posts"><em>Сообщений:</em> 431</p>		
+		
+		<br>	</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">mentalrisk2 &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89302112#89302112">23-Июн-26 00:40</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 50 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89302112">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-25">
+						<div class="post_body" id="p-89302112" data-ext_link_data='{"p":89302112,"t":6873596,"f":252,"u":24733802}'>
+													"Новая Республика пытается защитить идеалы" - есть где в тексте эти идеалы, почитать?											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=24733802">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=24733802">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89302354" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89302354"></a>
+		
+		
+				<p class="nick ">999999999555<wbr>55</p>
+		
+		
+								<p class="joined"><em>Стаж:</em> 5 лет 8 месяцев</p>		<p class="posts"><em>Сообщений:</em> 28</p>		
+		
+		<br>	</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">999999999555<wbr>55 &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89302354#89302354">23-Июн-26 05:22</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 4 часа)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89302354">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-26">
+						<div class="post_body" id="p-89302354" data-ext_link_data='{"p":89302354,"t":6873596,"f":252,"u":45997030}'>
+													<div class="sp-wrap">
+<div class="sp-head folded"><span>скрытый текст</span></div>
+<div class="sp-body"><a href="https://fastpic.org/view/127/2026/0623/2bfb55748b7e74bf7e30b914a2151873.jpeg.html" class="postLink"><var class="postImg" title="https://i127.fastpic.org/big/2026/0623/73/2bfb55748b7e74bf7e30b914a2151873.jpeg">&#10;</var></a></div>
+</div>											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=45997030">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=45997030">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89302429" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89302429"></a>
+		
+		
+				<p class="nick ">andrewalexk</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/3/4/16961804.jpg" alt=""></p>		<p class="joined"><em>Стаж:</em> 16 лет 1 месяц</p>		<p class="posts"><em>Сообщений:</em> 106</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">andrewalexk &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89302429#89302429">23-Июн-26 06:46</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 1 час 23 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89302429">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-27">
+						<div class="post_body" id="p-89302429" data-ext_link_data='{"p":89302429,"t":6873596,"f":252,"u":16961804}'>
+													<img class="smile" src="https://static.rutracker.cc/smiles/icon_smile.gif" alt=""> не совсем понятна таргет-группа фильма... 6+?<br>
+так они все привыкли к компьютерной графике .. как их отцы<br>
+а тут куклы...											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=16961804">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=16961804">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89302514" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89302514"></a>
+		
+		
+				<p class="nick ">apleon</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/4/81/24588081.jpg" alt=""></p>		<p class="joined"><em>Стаж:</em> 14 лет 6 месяцев</p>		<p class="posts"><em>Сообщений:</em> 1222</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">apleon &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89302514#89302514">23-Июн-26 07:54</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 1 час 7 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89302514">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-28">
+						<div class="post_body" id="p-89302514" data-ext_link_data='{"p":89302514,"t":6873596,"f":252,"u":24588081}'>
+													<div class="q-wrap">
+<div class="q-head"><span><b>andrewalexk</b> писал(а):</span></div>
+<div class="q"><u class="q-post">89302429</u> <img class="smile" src="https://static.rutracker.cc/smiles/icon_smile.gif" alt=""> не совсем понятна таргет-группа фильма... 6+?<br>
+так они все привыкли к компьютерной графике .. как их отцы<br>
+а тут куклы...</div>
+</div>
+Это Дисней - у него группа 6-											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=24588081">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=24588081">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89302563" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89302563"></a>
+		
+		
+				<p class="nick ">andy.andy</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/4/37/24011337.jpg" alt=""></p>		<p class="joined"><em>Стаж:</em> 14 лет 7 месяцев</p>		<p class="posts"><em>Сообщений:</em> 3553</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">andy.andy &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89302563#89302563">23-Июн-26 08:34</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 40 мин., ред. 23-Июн-26 08:34)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89302563">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-29">
+						<div class="post_body" id="p-89302563" data-ext_link_data='{"p":89302563,"t":6873596,"f":252,"u":24011337}'>
+													<span class="post-b">99999999955555</span><br>
+знатно заморочился!
+<div class="q-wrap">
+<div class="q-head"><span><b>andrewalexk</b> писал(а):</span></div>
+<div class="q"><u class="q-post">89302429</u> <img class="smile" src="https://static.rutracker.cc/smiles/icon_smile.gif" alt=""> не совсем понятна таргет-группа фильма... 6+?<br>
+так они все привыкли к компьютерной графике .. как их отцы<br>
+а тут куклы...</div>
+</div>
+верняк! у Грогу как будто ревматизм с детства - весь обмороженый, да и другие "малыши"... видно, что куклы - Маппет-шоу в действии...<br>
+в кинцо вложились, а эти - деревянные все... <img class="smile" src="https://static.rutracker.cc/smiles/icon_confused.gif" alt="">											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=24011337">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=24011337">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89302610" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89302610"></a>
+		
+		
+				<p class="nick ">vvaassyyaa</p>
+		
+		
+								<p class="joined"><em>Стаж:</em> 8 лет 11 месяцев</p>		<p class="posts"><em>Сообщений:</em> 56</p>		
+		
+		<br>	</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">vvaassyyaa &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89302610#89302610">23-Июн-26 08:56</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 22 мин., ред. 23-Июн-26 08:56)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89302610">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-30">
+						<div class="post_body" id="p-89302610" data-ext_link_data='{"p":89302610,"t":6873596,"f":252,"u":42451863}'>
+													Маппет-шоу на новый лад. Убогая кукла, не мог избавится от ощущения что у этого Грогу прям в жопе торчит рука кукловода, Педру Паскаля все упорно кличут "манда", сюжет никакущий...<br>
+Лучше уж Дарт Мол - повелитель теней смотреть, и то повеселее.<br>
+И глядя на этого Грогу и его прадеда Йоду наконец дошло что это за национальность. Это ж дети крокодила Гены и Чебурашки. Зеленые, маленькие, с большими ушами... Только вот кто кого - крокодил Чебурашку или наоборот пока не вкурил <img class="smile" src="https://static.rutracker.cc/smiles/icon_smile.gif" alt="">											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=42451863">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=42451863">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+</table><!--/topic_main-->
+
+<script>$('img.smile').remove();</script>
+
+<table id="pagination" class="topic">
+<tr>
+	<td class="nav pad_6 row1">
+		<p style="float: left">Страница <b>1</b> из <b>2</b></p>
+		<p style="float: right" class="hide-for-print"><span class="pg-jump-menu"><a class="menu-root" href="#pg-jump" onclick="BB.focus_pg_input();">Страницы</a> :&nbsp;&nbsp;</span><b>1</b>, <a class="pg" href="viewtopic.php?t=6873596&amp;start=30">2</a>&nbsp;&nbsp;<a class="pg" href="viewtopic.php?t=6873596&amp;start=30">След.</a></p>
+	</td>
+</tr>
+</table><!--/pagination-->
+
+
+<table class="topic hide-for-print">
+<tr>
+	<td class="catBottom med">
+		&nbsp;
+	</td>
+</tr>
+</table>
+
+<table class="w100 hide-for-print" style="padding-top: 2px;">
+<tr>
+	<td class="vTop">
+		<a href="posting.php?mode=reply&amp;t=6873596"><img src="https://static.rutracker.cc/templates/v1/images/reply.gif" alt="Ответить"></a>
+	</td>
+	<td class="nav w100" style="padding-left: 8px;">
+		<a href="index.php">Главная</a>
+		<em>&raquo;</em> <a href="index.php?c=2">Кино, Видео и ТВ</a>
+				<em>&raquo;</em> <a href="viewforum.php?f=7">Зарубежное кино</a>
+				<em>&raquo;</em> <a href="viewforum.php?f=252">Фильмы 2026</a>
+	</td>
+</tr>
+</table>
+
+<div class="bottom_info hide-for-print">
+
+	<div class="tRight">
+		<span id="jumpbox-wrap"></span>
+	</div>
+
+	<table class="w100">
+	<tr>
+				<td class="tRight med vTop">
+					</td>
+	</tr>
+	</table>
+
+</div><!--/bottom_info-->
+
+
+
+				</div><!--/main_content_wrap-->
+			</td><!--/main_content-->
+
+		</tr>
+		</table>
+	</div><!--/page_content-->
+
+	<!--page_footer-->
+	<div id="page_footer" class="hide-for-print">
+
+		
+		<div class="clear"></div>
+
+		<nav id="footer-info-links">
+			<div>
+				<a href="info.php?show=user_agreement" rel="nofollow">Условия использования</a>
+				&middot;
+				<a href="info.php?show=advert" rel="nofollow">Реклама на сайте</a>
+				&middot;
+				<a href="info.php?show=copyright_holders" rel="nofollow">Для правообладателей</a>
+				&middot;
+				<a href="info.php?show=press" rel="nofollow">Для прессы</a>
+				&middot;
+				<a href="viewtopic.php?t=2234744">Для провайдеров</a>
+				<!--&middot;-->
+				<!--<a href="http://rutracker.news">Блог</a>-->
+				&middot;
+				<a href="https://rutracker.wiki">Торрентопедия</a>
+			</div>
+			<div>
+				<a href="viewtopic.php?t=1045"><b>Правила</b></a>
+				&middot;
+				<a href="/go/8" rel="nofollow">Кому задать вопрос</a>
+				&middot;
+				<a href="viewforum.php?f=1538">Авторские раздачи</a>
+				&middot;
+				<a href="viewforum.php?f=1289">Конкурсы</a>
+				&middot;
+				<a href="viewforum.php?f=2332">Новости &quot;Хранителей&quot; и &quot;Антикваров&quot;</a>
+				&middot;
+				<a href="#" onclick="return post2url('index.php', {rand_rel: 1});" rel="nofollow">Случайная раздача</a>
+			</div>
+		</nav>
+
+		
+		<div class="tCenter nowrap" style="margin: 18px 4px 4px 4px;">
+								</div>
+
+		<div class="footer-bottom-links">
+			<ul class="inlined middot-separated">
+				<li><a href="groupcp.php?g=104792" rel="nofollow" target="_blank">Администрация</a></li>
+				<li><a href="groupcp.php?g=104787" rel="nofollow" target="_blank">Модераторы</a></li>
+				<li><a href="groupcp.php?g=104841" rel="nofollow" target="_blank">Тех. помощь</a></li>
+				<li><a href="https://t.me/rutracker_news" rel="nofollow" target="_blank">Telegram-канал</a></li>
+			</ul>
+			<div class="wide">
+									<script>
+					$(function () {
+						var title = "";
+						var src = "https://counter.yadro.ru/hit?t44.1;r" + encodeURIComponent(document.referrer) +
+							((typeof (screen) == "undefined") ? "" : ";s" + screen.width + "*" + screen.height + "*" + (screen.colorDepth ? screen.colorDepth : screen.pixelDepth)) +
+							";u" + encodeURIComponent(document.URL) + ";h" + encodeURIComponent(title.substring(0, 80)) + ";" + Math.random();
+						$('<img src="' + src + '" alt="">').on('load', function () {
+							$('#liveinternet').append(this);
+						});
+					});
+					</script>
+					<a id="liveinternet" href="https://www.liveinternet.ru/stat/rutracker.org/index.html?lang=ru" target="_blank"></a>
+							</div>
+			<ul class="inlined middot-separated">
+																							</ul>
+		</div>
+
+	</div><!--/page_footer-->
+</div><!--/page_container-->
+
+
+<div id="ajax-loading"><b>Loading...</b></div>
+<div id="ajax-error"><b>Error</b></div>
+<style>
+#bb-alert-box {
+	width: auto;
+	max-width: 800px;
+	line-height: 18px;
+	display: none;
+}
+#bb-alert-msg {
+	min-width: 400px;
+	max-height: 400px;
+	margin: 50px 20px;
+	padding: 10px;
+	overflow: auto;
+	text-align: center;
+}
+.bb-alert-err {
+	color: #7E0000;
+	background: #FFEEEE;
+	box-shadow: 0 0 20px #B85353;
+	font-weight: bold;
+}
+</style>
+<div id="bb-alert-box">
+	<div id="bb-alert-msg"></div>
+</div>
+<div id="modal-blocker"></div>
+
+<script>
+$(function () {
+	if (!BB.hasET() && BB.getUrlParam('view') !== 'print') {
+		BB.navbar.init();
+	}
+});
+</script>
+<div id="nav-panel" class="nav-hidden-arrow hide-for-print">
+	<div id="nav-up" class="nav-btn" title="Вверх">
+		<span class="nav-icon"></span>
+	</div>
+	<div id="nav-settings" class="nav-btn">
+		<span class="nav-icon" title="Настройки"></span>
+		<ul id="nav-opt-menu">
+			<li class="nav-event" data-event="click">Показывать по клику</li>
+			<li class="nav-event" data-event="mouseenter">Показывать по наведению</li>
+		</ul>
+	</div>
+	<div id="nav-down" class="nav-btn" title="Вниз">
+		<span class="nav-icon"></span>
+	</div>
+	<div class="nav-hidden-overlay"></div>
+</div>
+
+	</div><!--/body_container-->
+
+<script>(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML="window.__CF$cv$params={r:'a106511ebb9b2d8e',t:'MTc4MjI0NzMyMQ=='};var a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);";b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script></body>
+</html>

--- a/core/network/rutracker/src/test/resources/fixtures/topic_torrent_guest.html
+++ b/core/network/rutracker/src/test/resources/fixtures/topic_torrent_guest.html
@@ -1,0 +1,2298 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+
+<meta charset="Windows-1251">
+<meta name="description" content="Мандалорец и Грогу / The Mandalorian &amp; Grogu (Джон Фавро / Jon Favreau) [2026, США, фантастика, фэнтези, боевик, приключения, семейный, WEBRip] [Локализованный видеоряд] Dub (MovieDalen) &raquo; Фильмы 2026 :: RuTracker.org">
+<meta name="robots" content="nofollow">
+	<link rel="canonical" href="https://rutracker.org/forum/viewtopic.php?t=6873596">
+
+<title>Мандалорец и Грогу / The Mandalorian &amp; Grogu (Джон Фавро / Jon Favreau) [2026, США, фантастика, фэнтези, боевик, приключения, семейный, WEBRip] [Локализованный видеоряд] Dub (MovieDalen) :: RuTracker.org</title>
+
+<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+<link rel="manifest" href="/manifest.json">
+<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
+<meta name="msapplication-TileColor" content="#2b5797">
+<meta name="msapplication-TileImage" content="/mstile-144x144.png">
+<meta name="theme-color" content="#ffffff">
+
+<link rel="search" type="application/opensearchdescription+xml" title="Поиск на RuTracker.org" href="https://static.rutracker.cc/opensearch.xml">
+
+<script>
+window.BB = {
+	cur_domain: location.hostname.replace(/.*?(([a-z0-9-]+\.){1,2}[a-z0-9-]+)$/, '$1'),
+	form_token: '',
+	opt_js: {},
+
+	IS_GUEST: !!'1',
+	IMG_URL: 'https://static.rutracker.cc/templates/v1/images',
+	SMILES_URL: 'https://static.rutracker.cc/smiles',
+	catId: 2,
+	FORUM_ID: 252,
+	parentForumId: 7,
+		PG_PER_PAGE: '30',
+	PG_BASE_URL: 'viewtopic.php?t=6873596',
+		COOKIE_MARK: 'bb_mark_read',
+	};
+BB.cookie_defaults = {
+	domain: '.' + BB.cur_domain,
+	path: "/forum/",
+};
+</script>
+<link href="https://static.rutracker.cc/templates/v1/min/eb83350bae3880e4073b81d26294de5d.all.min.css" rel="stylesheet">
+<script src="https://static.rutracker.cc/templates/v1/min/4e695e8ea9cf5a1dcc7aed231b887c51.lib.min.js"></script>
+<script src="https://static.rutracker.cc/templates/v1/min/3b60ab3546ba966484df4c3099b918ab.bb.min.js"></script>
+
+
+
+<style>
+.invisible-el {
+	/* @include element-invisible(); */
+	clip: rect(1px, 1px, 1px, 1px);
+	height: 1px;
+	overflow: hidden;
+	position: absolute !important;
+	width: 1px;
+}
+.hidden, .menu-sub, #ajax-loading, #ajax-error, var.ajax-params, #modal-blocker, .q-post {
+	display: none;
+}
+/**/
+#logo {
+	min-height: auto;
+}
+/**/
+/* temp */
+/* temp end */
+</style>
+
+<noscript>
+	<style>
+	.sp-body {
+		display: block; /* for bots */
+	}
+	</style>
+</noscript>
+
+</head>
+
+<body class="" style="">
+
+<div id="invisible-heap" class="invisible-el"></div>
+<div id="preload" class="invisible-el"></div>
+
+<div class="menu-sub" id="pg-jump">
+	<table style="border-spacing: 1px;">
+	<tr>
+		<th style="padding: 2px;">К странице...</th>
+	</tr>
+	<tr>
+		<td style="padding: 2px;">
+			<form onsubmit="BB.go_to_page( $('#pg-page').val() ); return false;">
+				<input id="pg-page" type="text" size="5" maxlength="4">
+				<input type="submit" value="Перейти">
+			</form>
+		</td>
+	</tr>
+	</table>
+</div>
+
+
+<div id="body_container">
+
+		<script>
+	if (top != self && !self.location.hostname.match(BB.allowed_translator_hosts)) {
+		$(function () {
+			$('body').html('<h1 style="text-align: center;"><br><br>Похоже, вас пытаются обмануть<br>frame\'s hostname: ' + self.location.hostname + '</h1>');
+			throw new Error('in frame');
+		});
+	}
+		</script>
+
+	<div id="page_container">
+
+		<div id="page_header" class="hide-for-print">
+
+			<div id="main-nav" class="site-nav clearfix">
+				<ul class="inlined middot-separated floatL">
+					<li>
+						<a href="index.php"><b>Главная</b></a>
+					</li>
+					<li>
+													<a href="tracker.php" rel="nofollow"><b>Трекер</b></a>
+											</li>
+					<li>
+						<a href="search.php" rel="nofollow"><b>Поиск</b></a>
+					</li>
+					<li>
+						<a href="groupcp.php" rel="nofollow"><b>Группы</b></a>
+					</li>
+					<li>
+						<a href="https://rutracker.wiki/" target="_blank"><b>FAQ</b></a>
+					</li>
+					<li>
+						<a href="viewtopic.php?t=6812335" style="color: #7b1fa2;"><b>VPN</b></a>
+					</li>
+					<li>
+						<a href="viewtopic.php?t=1045"><b>Правила</b></a>
+					</li>
+					<li>
+						<a href="viewtopic.php?t=6452965" style="color: #880e4f;"><b>Донаты</b></a>
+					</li>
+									</ul>
+											</div>
+			<!--/main-nav-->
+
+			
+			<div id="logo">
+				<table style="">
+				<tr>
+					<td id="logo-td" style="padding: 3px 7px 3px 15px;">
+						<a href="index.php" class="site-logo-link">
+								<img class="site-logo"
+		src="https://static.rutracker.cc/logo/logo-3.svg"
+		style=""
+		alt="logo">
+							</a>
+					</td>
+					<td class="tCenter w100" style="padding: 6px 10px 0 3px;">
+											</td>
+				</tr>
+				</table>
+			</div>
+			<!--/logo-->
+
+						<div class="topmenu">
+				<table class="w100">
+				<tr>
+					
+					<td class="tCenter pad_2 nowrap">
+						<div>
+															<a href="profile.php?mode=register" rel="nofollow"><b>Регистрация</b></a>
+								&nbsp;&#0183;&nbsp;
+								<a href="#" onclick="BB.toggle_top_login(); return false;" tabindex="5"><b>Вход</b></a>
+
+								<div id="top-login-box">
+									<form id="quick-search-guest" method="get" action="tracker.php">
+										<input id="search-text-guest" type="text" name="nm" value="" tabindex="1" accesskey="q">
+										<input type="submit" value="поиск" tabindex="2">
+									</form>
+									<form id="login-form-quick" method="post" action="login.php" style="display: none;">
+																				<input id="top-login-uname" type="text" name="login_username" tabindex="1" accesskey="l" placeholder="имя">
+										<input id="top-login-pwd" type="password" name="login_password" tabindex="2" placeholder="пароль">
+										<label title="Защищенное соединение" class="login-ssl-block" style="display: none;">
+											<input class="login-ssl" type="checkbox" tabindex="3" checked>SSL
+										</label>
+										<input id="top-login-btn" type="submit" name="login" value="вход" tabindex="4">
+									</form>
+								</div>
+
+								<a href="otp.php" rel="nofollow"><b>Забыли имя или пароль?</b></a>
+													</div>
+					</td>
+
+					
+				</tr>
+				</table>
+			</div><!--/topmenu-->
+			
+			
+		</div>
+		<!--/page_header-->
+
+		
+		<div id="page_content">
+			<table style="width: 100%; border: none;">
+			<tr>
+
+				
+				<td id="main_content">
+					<div id="main_content_wrap">
+
+						
+						
+						
+						
+						<!--/page_header.tpl-->
+
+
+<script>
+$(function () {
+		BB.initMagnetLinks();
+	});
+</script>
+
+
+
+
+<table class="w100">
+<tr>
+	<td class="w100 vBottom pad_2">
+		<h1 class="maintitle">
+			<a id="topic-title" class="topic-title-6873596 highlight-cyrillic" href="https://rutracker.org/forum/viewtopic.php?t=6873596">Мандалорец и Грогу / The Mandalorian &amp; Grogu (Джон Фавро / Jon Favreau) [2026, США, фантастика, фэнтези, боевик, приключения,<wbr> семейный, WEBRip] [Локализованн<wbr>ый видеоряд] Dub (MovieDalen)<wbr></a>
+		</h1>
+		<div class="small hide-for-print" style="margin: 12px 4px 8px;">
+			<b><span class="pg-jump-menu"><a class="menu-root" href="#pg-jump" onclick="BB.focus_pg_input();">Страницы</a> :&nbsp;&nbsp;</span><b>1</b>, <a class="pg" href="viewtopic.php?t=6873596&amp;start=30">2</a>&nbsp;&nbsp;<a class="pg" href="viewtopic.php?t=6873596&amp;start=30">След.</a></b>
+		</div>
+		
+		<table class="w100">
+		<tr>
+			<td class="pad_2 hide-for-print">
+				<a href="posting.php?mode=reply&amp;t=6873596"><img src="https://static.rutracker.cc/templates/v1/images/reply.gif" alt="Ответить"></a>
+			</td>
+			<td class="nav t-breadcrumb-top w100 pad_2">
+				&nbsp;<a href="index.php?c=2">Кино, Видео и ТВ</a>
+								<em>&raquo;</em> <a href="viewforum.php?f=7">Зарубежное кино</a>
+								<em>&raquo;</em> <a href="viewforum.php?f=252">Фильмы 2026</a>
+			</td>
+		</tr>
+		</table>
+
+	</td>
+	<td class="pad_2 hide-for-print">
+			</td>
+</tr>
+</table>
+
+
+
+
+
+<table class="topic" id="topic_main">
+<tbody class="hide-for-print">
+<tr>
+	<th colspan="2" class="thHead">
+		<div id="soc-container" data-share_url="https://rutracker.org/forum/viewtopic.php?t=6873596" data-share_title="Мандалорец и Грогу / The Mandalorian &amp; Grogu (Джон Фавро / Jon Favreau) [2026, США, фантастика, фэнтези, боевик, приключения, семейный, WEBRip] [Локализованный видеоряд] Dub (MovieDalen)">&nbsp;</div>
+	</th>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89299512" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89299512"></a>
+		
+		
+				<p class="nick nick-author">порошков</p>
+		
+		
+				<p class="rank_img"><img class="user-rank" src="https://static.rutracker.cc/ranks/s_mod.gif" alt="Moderator"></p>		<p class="avatar"><img src="https://static.rutracker.cc/avatars/1/1/8679101.png" alt=""></p>		<p class="joined"><em>Стаж:</em> 17 лет 4 месяца</p>		<p class="posts"><em>Сообщений:</em> 26743</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">порошков &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?t=6873596">22-Июн-26 04:19</a>
+				</span>
+												<span class="posted_since hide-for-print">(1 день 19 часов назад)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+								
+				
+																											</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-1">
+												<div class="post_body" id="p-89299512" data-ext_link_data='{"p":89299512,"t":6873596,"f":252,"u":8679101}'>
+													<span style="font-size: 24px; line-height: normal;"><span class="post-b"><span class="post-u">Мандалорец и Грогу / The Mandalorian &amp; Grogu</span></span></span><span class="post-br"><br></span><var class="postImg postImgAligned img-right" title="https://i6.imageban.ru/out/2026/06/22/422699cc36b18bc4ae051d1b083630d4.jpg">&#10;</var><span class="post-font-serif1"><span style="font-size: 15px; line-height: normal;"><span class="post-b">Страна</span>: США<br>
+<span class="post-b">Жанр</span>: фантастика, фэнтези, боевик, приключения, семейный<br>
+<span class="post-b">Год выпуска</span>: 2026<br>
+<span class="post-b">Продолжительность</span>: 02:11:55<hr class="post-hr"><span class="post-b">Перевод</span>: Профессиональный (дублированный) | <span class="post-b"><span class="p-color" style="color: darkred;">MovieDalen</span></span><br>
+<span class="post-b">Субтитры</span>: русские (forced - hardsub)<br>
+<span class="post-b">Оригинальная аудиодорожка</span>: нет<hr class="post-hr"><span class="post-b">Режиссер</span>:<br>
+Джон Фавро / Jon Favreau<hr class="post-hr"><span class="post-b">В ролях</span>: Педро Паскаль, Джереми Аллен Уайт, Стивен Блум, Сигурни Уивер, Брендан Уэйн, Латиф Кроудер, Джонатан Койн, Мэттью Уиллиг<hr class="post-hr"><span class="post-b">Описание</span>: Империя пала, но её военачальники всё ещё держат под своим контролем части галактики. Зарождающаяся Новая Республика пытается защитить идеалы, за которые сражались повстанцы, и нанимает для задания мандалорца Дина Джарина, известного охотника за головами, и его юного ученика Грогу.<hr class="post-hr"><a href="https://www.kinopoisk.ru/film/5437088/" class="postLink"><var class="postImg" title="https://rating.kinopoisk.ru/5437088.gif">&#10;</var></a><hr class="post-hr"><span class="post-b">Качество видео</span>: WEBRip<br>
+<span class="post-b">Формат видео</span>: AVI<span class="post-br"><br></span><span class="post-b">Видео</span>: 720x304 (2.37:1), 24.000 fps, XviD build 73 ~1377 kbps avg, 0.26 bit/pixel<br>
+<span class="post-b">Аудио</span>: 48 kHz, AC3 Dolby Digital, 2/0 (L,R) ch, ~192 kbps<hr class="post-hr"></span></span>
+<div class="post-box-default">
+<div class="post-box"><span class="post-b"><a href="https://cloud.mail.ru/public/2a6L/UmptPcziP" class="postLink">Сэмпл</a></span></div>
+</div>
+<hr class="post-hr">
+<div class="sp-wrap">
+<div class="sp-head folded"><span>MediaInfo</span></div>
+<div class="sp-body">
+<pre class="post-pre"></pre>
+<div class="c-wrap">
+<div class="c-head"><b>Код:</b></div>
+<div class="c-body"><br>
+Формат&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; AVI<br>
+Формат/Информация&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; Audio Video Interleave<br>
+Настройки формата&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; BitmapInfoHeader / WaveFormatEx<br>
+Размер файла&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; 1,46 Гбайт<br>
+Продолжительность&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; 2 ч. 11 м.<br>
+Общий битрейт&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; 1 579 Кбит/сек<br>
+Частота кадров&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; 24,000 кадра/сек<br>
+Заголовок&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; Мандалорец и Грогу_2026_WEBRip<br>
+Программа кодирования&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; VirtualDubMod 1.5.10.3 | www.virtualdub-fr.org || (build 2550/release&#41;<br>
+Авторское право&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; порошков<span class="post-br"><br></span>Видео<br>
+Идентификатор&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; 0<br>
+Формат&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; MPEG-4 Visual<br>
+Профиль формата&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; Advanced Simple@L5<br>
+Настройки формата&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; BVOP1 / Custom Matrix<br>
+Параметр BVOP формата&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; 1<br>
+Параметр QPel формата&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; Нет<br>
+Параметр GMC формата&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; Без точки перехода<br>
+Параметр Matrix формата&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; Выборочная<br>
+Идентификатор кодека&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; XVID<br>
+Идентификатор кодека/Подсказка&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; XviD<br>
+Продолжительность&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; 2 ч. 11 м.<br>
+Битрейт&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; 1 378 Кбит/сек<br>
+Ширина&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; 720 пикселей<br>
+Высота&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; 304 пикселя<br>
+Соотношение сторон&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; 2,35&#58;1<br>
+Частота кадров&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; 24,000 кадра/сек<br>
+Цветовое пространство&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; YUV<br>
+Цветовая субдискретизация&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; 4&#58;2&#58;0<br>
+Битовая глубина&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; 8 бит<br>
+Тип развёртки&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; Прогрессивная<br>
+Метод сжатия&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; С потерями<br>
+Бит/(Пиксели*Кадры&#41;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; 0.262<br>
+Размер потока&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; 1,27 Гбайт (87%&#41;<br>
+Библиотека кодирования&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; XviD 73<span class="post-br"><br></span>Аудио<br>
+Идентификатор&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; 1<br>
+Формат&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; AC-3<br>
+Формат/Информация&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; Audio Coding 3<br>
+Коммерческое название&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; Dolby Digital<br>
+Идентификатор кодека&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; 2000<br>
+Продолжительность&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; 2 ч. 11 м.<br>
+Вид битрейта&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; Постоянный<br>
+Битрейт&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; 192 Кбит/сек<br>
+Каналы&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; 2 канала<br>
+Расположение каналов&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; L R<br>
+Частота дискретизации&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; 48,0 КГц<br>
+Частота кадров&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; 31,250 кадров/сек (1536 SPF&#41;<br>
+Метод сжатия&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; С потерями<br>
+Размер потока&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; 181 Мбайт (12%&#41;<br>
+Выравнивание&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; Разделение по промежуткам<br>
+Чередование, продолжительность&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; 42&nbsp; мс. (1,00 видеокадр&#41;<br>
+Чередование, продолжительность предзагру &#58; 500&nbsp; мс.<br>
+Вид сервиса&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; Complete Main<br>
+Нормализация звука речи&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; -15 dB<br>
+compr&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; -0.28 dB<br>
+ltrtcmixlev&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; -3.0 dB<br>
+ltrtsurmixlev&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; -3.0 dB<br>
+lorocmixlev&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; -3.0 dB<br>
+lorosurmixlev&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &#58; -3.0 dB<br>
+Нормализация звука речи, среднее&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; -15 dB<br>
+Нормализация звука речи, минимум&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&#58; -15 dB<br>
+Нормализация звука речи, максимум&nbsp; &nbsp; &nbsp; &nbsp; &#58; -15 dB<br></div>
+</div>
+</div>
+</div>
+<div class="sp-wrap">
+<div class="sp-head folded"><span>Скриншоты</span></div>
+<div class="sp-body"><a href="https://imageban.ru/show/2026/06/22/4431dbf17fe1a390f3feab062cc337fb/png" class="postLink"><var class="postImg" title="https://i3.imageban.ru/thumbs/2026.06.22/4431dbf17fe1a390f3feab062cc337fb.png">&#10;</var></a><a href="https://imageban.ru/show/2026/06/22/ce311500a323ba0998e09c7e06f8ebdc/png" class="postLink"><var class="postImg" title="https://i5.imageban.ru/thumbs/2026.06.22/ce311500a323ba0998e09c7e06f8ebdc.png">&#10;</var></a><a href="https://imageban.ru/show/2026/06/22/a1ceb01fd8c9b9f0b4efbebd2621393a/png" class="postLink"><var class="postImg" title="https://i7.imageban.ru/thumbs/2026.06.22/a1ceb01fd8c9b9f0b4efbebd2621393a.png">&#10;</var></a><a href="https://imageban.ru/show/2026/06/22/034d98c8a23d79d3e2c1aac6f9aef0f6/png" class="postLink"><var class="postImg" title="https://i1.imageban.ru/thumbs/2026.06.22/034d98c8a23d79d3e2c1aac6f9aef0f6.png">&#10;</var></a><br>
+<a href="https://imageban.ru/show/2026/06/22/b5dc017248020a09ea7a109003f70eeb/png" class="postLink"><var class="postImg" title="https://i8.imageban.ru/thumbs/2026.06.22/b5dc017248020a09ea7a109003f70eeb.png">&#10;</var></a><a href="https://imageban.ru/show/2026/06/22/b6a47c18c95f7bda11e2d6657665b892/png" class="postLink"><var class="postImg" title="https://i1.imageban.ru/thumbs/2026.06.22/b6a47c18c95f7bda11e2d6657665b892.png">&#10;</var></a><a href="https://imageban.ru/show/2026/06/22/82a72844129438af94314ea19d2430e1/png" class="postLink"><var class="postImg" title="https://i5.imageban.ru/thumbs/2026.06.22/82a72844129438af94314ea19d2430e1.png">&#10;</var></a><a href="https://imageban.ru/show/2026/06/22/8e98f17428e4f838a62378b3f3ac2f71/png" class="postLink"><var class="postImg" title="https://i4.imageban.ru/thumbs/2026.06.22/8e98f17428e4f838a62378b3f3ac2f71.png">&#10;</var></a></div>
+</div>
+<span class="post-align" style="text-align: center;"><span class="post-font-serif1"><span style="font-size: 16px; line-height: normal;"><span class="post-b">При выходе лучшего качаества раздачу обновлю.</span></span></span></span>											</div><!--/post_body-->
+
+			
+			<div class="clear" style="height: 8px;"></div>
+
+			
+			
+			<fieldset class="attach">
+				<legend>Download</legend>
+								<div class="attach_link guest">
+					<ul class="inlined middot-separated">
+						<li>
+							<a href="magnet:?xt=urn:btih:E53DA7E8D44BD5016BF8074A0E8A49CA0EE7EE17&tr=http%3A%2F%2Fbt4.t-ru.org%2Fann%3Fmagnet" class="magnet-link" data-topic_id="6873596" >
+								<img src="https://static.rutracker.cc/templates/v1/images/magnet_1.svg" alt="">Скачать по magnet-ссылке</a>
+						</li>
+												<li>1.46&nbsp;GB</li>
+					</ul>
+				</div>
+												<div class="attachment-disclaimer">
+					Rutracker.org не распространяет и не хранит электронные версии произведений, а лишь предоставляет доступ к создаваемому
+					пользователями каталогу ссылок на <a href="https://ru.wikipedia.org/wiki/BitTorrent" target="_blank">торрент-файлы</a>,
+					которые содержат только списки хеш-сумм
+				</div>
+				<div class="attachment-disclaimer">
+					<a href="/go/1" target="_blank"><b>Как скачивать?</b></a>
+					<i>(для скачивания <b>.torrent</b> файлов необходима
+						<a href="profile.php?mode=register" target="_blank"><b>регистрация</b></a>)</i>
+				</div>
+			</fieldset>
+
+			
+			
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=8679101">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=8679101">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89299549" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89299549"></a>
+		
+		
+				<p class="nick ">Dark_ReN</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/4/24/20627024.png" alt=""></p>		<p class="joined"><em>Стаж:</em> 15 лет 6 месяцев</p>		<p class="posts"><em>Сообщений:</em> 1310</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">Dark_ReN &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89299549#89299549">22-Июн-26 05:17</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 58 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89299549">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-2">
+						<div class="post_body" id="p-89299549" data-ext_link_data='{"p":89299549,"t":6873596,"f":252,"u":20627024}'>
+													афигенчик, я лично в восторге! ясно, что марвелщина/5 класс, но это не нудный сериал, оно бодро и динамично, а графон, сама картинка, столько ярких деталей, такие виды, юморок, вообще.. отлично, имхо 8.5/10											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=20627024">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=20627024">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89299596" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89299596"></a>
+		
+		
+				<p class="nick ">13stakanoff</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/2/94/13788994.jpg" alt=""></p>		<p class="joined"><em>Стаж:</em> 16 лет 6 месяцев</p>		<p class="posts"><em>Сообщений:</em> 45</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">13stakanoff &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89299596#89299596">22-Июн-26 06:18</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 1 час)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89299596">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-3">
+						<div class="post_body" id="p-89299596" data-ext_link_data='{"p":89299596,"t":6873596,"f":252,"u":13788994}'>
+													Спасибо за труды											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=13788994">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=13788994">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89299668" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89299668"></a>
+		
+		
+				<p class="nick ">apleon</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/4/81/24588081.jpg" alt=""></p>		<p class="joined"><em>Стаж:</em> 14 лет 6 месяцев</p>		<p class="posts"><em>Сообщений:</em> 1222</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">apleon &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89299668#89299668">22-Июн-26 07:16</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 57 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89299668">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-4">
+						<div class="post_body" id="p-89299668" data-ext_link_data='{"p":89299668,"t":6873596,"f":252,"u":24588081}'>
+													Педро Паскаль в роли Джаббы? Надо подождать лучшего качества,											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=24588081">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=24588081">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89299827" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89299827"></a>
+		
+		
+				<p class="nick ">aida1970</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/2/3/10883403.jpg" alt=""></p>		<p class="joined"><em>Стаж:</em> 16 лет 11 месяцев</p>		<p class="posts"><em>Сообщений:</em> 13</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">aida1970 &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89299827#89299827">22-Июн-26 08:59</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 1 час 43 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89299827">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-5">
+						<div class="post_body" id="p-89299827" data-ext_link_data='{"p":89299827,"t":6873596,"f":252,"u":10883403}'>
+													манда ? кто в роли манды, не СИГУРНИ УИВЕР?											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=10883403">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=10883403">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89299960" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89299960"></a>
+		
+		
+				<p class="nick ">Шпил</p>
+		
+		
+								<p class="joined"><em>Стаж:</em> 3 месяца 20 дней</p>		<p class="posts"><em>Сообщений:</em> 15</p>		
+		
+		<br>	</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">Шпил &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89299960#89299960">22-Июн-26 10:07</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 1 час 7 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89299960">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-6">
+						<div class="post_body" id="p-89299960" data-ext_link_data='{"p":89299960,"t":6873596,"f":252,"u":54695927}'>
+													Спасибо, забираем !											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=54695927">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=54695927">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89300081" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89300081"></a>
+		
+		
+				<p class="nick ">apleon</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/4/81/24588081.jpg" alt=""></p>		<p class="joined"><em>Стаж:</em> 14 лет 6 месяцев</p>		<p class="posts"><em>Сообщений:</em> 1222</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">apleon &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89300081#89300081">22-Июн-26 11:07</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 1 час)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89300081">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-7">
+						<div class="post_body" id="p-89300081" data-ext_link_data='{"p":89300081,"t":6873596,"f":252,"u":24588081}'>
+													Cигурни полковницу играет, согласно локализаторам <img class="smile" src="https://static.rutracker.cc/smiles/icon_lol.gif" alt=""><br>
+Фильм очень хорошо зашёл в кинотеатре.											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=24588081">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=24588081">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89300141" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89300141"></a>
+		
+		
+				<p class="nick ">Dzherelo</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/9/99/49789099.jpg" alt=""></p>		<p class="joined"><em>Стаж:</em> 3 года 4 месяца</p>		<p class="posts"><em>Сообщений:</em> 129</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">Dzherelo &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89300141#89300141">22-Июн-26 11:32</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 24 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89300141">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-8">
+						<div class="post_body" id="p-89300141" data-ext_link_data='{"p":89300141,"t":6873596,"f":252,"u":49789099}'>
+													Как это говно 7 баллов набирает на КП и ИМДБ? Оно еще не окупилось даже (и уже вряд ли окупится).											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=49789099">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=49789099">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89300340" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89300340"></a>
+		
+		
+				<p class="nick ">proWin цэ ALL</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/9/47/49558547.jpg" alt=""></p>		<p class="joined"><em>Стаж:</em> 3 года 6 месяцев</p>		<p class="posts"><em>Сообщений:</em> 1330</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">proWin цэ ALL &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89300340#89300340">22-Июн-26 13:01</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 1 час 29 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89300340">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-9">
+						<div class="post_body" id="p-89300340" data-ext_link_data='{"p":89300340,"t":6873596,"f":252,"u":49558547}'>
+													<div class="q-wrap">
+<div class="q-head"><span><b>Dzherelo</b> писал(а):</span></div>
+<div class="q"><u class="q-post">89300141</u>Как это говно 7 баллов набирает</div>
+</div>
+фанты'c											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=49558547">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=49558547">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89300954" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89300954"></a>
+		
+		
+				<p class="nick ">Andrew_ma</p>
+		
+		
+								<p class="joined"><em>Стаж:</em> 17 лет 4 месяца</p>		<p class="posts"><em>Сообщений:</em> 21</p>		
+		
+		<br>	</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">Andrew_ma &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89300954#89300954">22-Июн-26 17:21</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 4 часа)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89300954">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-10">
+						<div class="post_body" id="p-89300954" data-ext_link_data='{"p":89300954,"t":6873596,"f":252,"u":8279888}'>
+													RIP StarWars... its a shit, not movie...											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=8279888">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=8279888">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89301076" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89301076"></a>
+		
+		
+				<p class="nick ">Snon</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/4/12/20217412.jpg" alt=""></p>		<p class="joined"><em>Стаж:</em> 15 лет 7 месяцев</p>		<p class="posts"><em>Сообщений:</em> 314</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">Snon &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89301076#89301076">22-Июн-26 18:04</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 43 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89301076">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-11">
+						<div class="post_body" id="p-89301076" data-ext_link_data='{"p":89301076,"t":6873596,"f":252,"u":20217412}'>
+													Педро и бокал грога.											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=20217412">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=20217412">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89301160" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89301160"></a>
+		
+		
+				<p class="nick ">kirikov8080</p>
+		
+		
+								<p class="joined"><em>Стаж:</em> 16 лет 6 месяцев</p>		<p class="posts"><em>Сообщений:</em> 345</p>		
+		
+		<br>	</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">kirikov8080 &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89301160#89301160">22-Июн-26 18:31</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 26 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89301160">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-12">
+						<div class="post_body" id="p-89301160" data-ext_link_data='{"p":89301160,"t":6873596,"f":252,"u":14066340}'>
+													Очень хотелось попереживать за главных героев, но они не дали ни единого шанса...											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=14066340">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=14066340">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89301187" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89301187"></a>
+		
+		
+				<p class="nick ">apleon</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/4/81/24588081.jpg" alt=""></p>		<p class="joined"><em>Стаж:</em> 14 лет 6 месяцев</p>		<p class="posts"><em>Сообщений:</em> 1222</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">apleon &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89301187#89301187">22-Июн-26 18:44</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 12 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89301187">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-13">
+						<div class="post_body" id="p-89301187" data-ext_link_data='{"p":89301187,"t":6873596,"f":252,"u":24588081}'>
+													<div class="q-wrap">
+<div class="q-head"><span><b>kirikov8080</b> писал(а):</span></div>
+<div class="q"><u class="q-post">89301160</u>Очень хотелось попереживать за главных героев, но они не дали ни единого шанса...</div>
+</div>
+Там не за кого переживать											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=24588081">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=24588081">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89301194" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89301194"></a>
+		
+		
+				<p class="nick ">Semperdun</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/7/52/36271252.jpg" alt=""></p>		<p class="joined"><em>Стаж:</em> 11 лет 11 месяцев</p>		<p class="posts"><em>Сообщений:</em> 133</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">Semperdun &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89301194#89301194">22-Июн-26 18:45</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 1 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89301194">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-14">
+						<div class="post_body" id="p-89301194" data-ext_link_data='{"p":89301194,"t":6873596,"f":252,"u":36271252}'>
+													Гаврила хейтил Мандалорца, Гаврила лорца отрицал											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=36271252">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=36271252">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89301209" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89301209"></a>
+		
+		
+				<p class="nick ">nevesom-8</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/4/78/24121078.jpg" alt=""></p>		<p class="joined"><em>Стаж:</em> 14 лет 7 месяцев</p>		<p class="posts"><em>Сообщений:</em> 158</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">nevesom-8 &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89301209#89301209">22-Июн-26 18:49</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 4 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89301209">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-15">
+						<div class="post_body" id="p-89301209" data-ext_link_data='{"p":89301209,"t":6873596,"f":252,"u":24121078}'>
+													Kung Lao - самый лучший перс!!!											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=24121078">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=24121078">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89301239" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89301239"></a>
+		
+		
+				<p class="nick ">waltage80</p>
+		
+		
+								<p class="joined"><em>Стаж:</em> 6 лет 1 месяц</p>		<p class="posts"><em>Сообщений:</em> 126</p>		
+		
+		<br>	</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">waltage80 &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89301239#89301239">22-Июн-26 18:59</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 9 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89301239">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-16">
+						<div class="post_body" id="p-89301239" data-ext_link_data='{"p":89301239,"t":6873596,"f":252,"u":45375146}'>
+													локализованный видеоряд Диснеевского кино это говно из говна<br>
+говно в квадрате											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=45375146">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=45375146">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89301280" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89301280"></a>
+		
+		
+				<p class="nick ">Redbear01</p>
+		
+		
+								<p class="joined"><em>Стаж:</em> 16 лет 3 месяца</p>		<p class="posts"><em>Сообщений:</em> 6</p>		
+		
+		<br>	</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">Redbear01 &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89301280#89301280">22-Июн-26 19:16</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 16 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89301280">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-17">
+						<div class="post_body" id="p-89301280" data-ext_link_data='{"p":89301280,"t":6873596,"f":252,"u":15766482}'>
+													Объясните пожалуйста. Ведь стриминги вещают до 4K разрешением, почему этот WEBRip такое лютое говнище? На видеомагнитофон как-то записывают или я что-то не понимаю											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=15766482">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=15766482">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89301358" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89301358"></a>
+		
+		
+				<p class="nick ">Nordwind 65</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/10/20/50995220.jpg" alt=""></p>		<p class="joined"><em>Стаж:</em> 2 года 7 месяцев</p>		<p class="posts"><em>Сообщений:</em> 142</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">Nordwind 65 &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89301358#89301358">22-Июн-26 19:48</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 31 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89301358">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-18">
+						<div class="post_body" id="p-89301358" data-ext_link_data='{"p":89301358,"t":6873596,"f":252,"u":50995220}'>
+													Звук, отстой, 2,0. Вилы.<br>
+Оригинальную дорогу положили, хотя бы, в 5,1, сделал бы многоканалку.<br>
+Тьфу, едрён-батом ети их подери.											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=50995220">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=50995220">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89301495" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89301495"></a>
+		
+		
+				<p class="nick ">russvarg</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/1/37/9413537.png" alt=""></p>		<p class="joined"><em>Стаж:</em> 17 лет 2 месяца</p>		<p class="posts"><em>Сообщений:</em> 178</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">russvarg &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89301495#89301495">22-Июн-26 20:37</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 49 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89301495">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-19">
+						<div class="post_body" id="p-89301495" data-ext_link_data='{"p":89301495,"t":6873596,"f":252,"u":9413537}'>
+													Те кто называет фильм говном его не смотрели или просто фанаты советских фильмов.											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=9413537">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=9413537">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89301545" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89301545"></a>
+		
+		
+				<p class="nick ">Doctor-ZLO</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/9/53/47433553.jpg" alt=""></p>		<p class="joined"><em>Стаж:</em> 4 года 7 месяцев</p>		<p class="posts"><em>Сообщений:</em> 96</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">Doctor-ZLO &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89301545#89301545">22-Июн-26 20:57</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 20 мин., ред. 22-Июн-26 20:57)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89301545">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-20">
+						<div class="post_body" id="p-89301545" data-ext_link_data='{"p":89301545,"t":6873596,"f":252,"u":47433553}'>
+													Отличный фильм, тока не понравилась музыкальное сопровождение. Ну не то совсем. Классический оркестр как в старых эпизодах был бы крут.											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=47433553">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=47433553">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89301576" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89301576"></a>
+		
+		
+				<p class="nick ">R.Richter</p>
+		
+		
+								<p class="joined"><em>Стаж:</em> 11 месяцев</p>		<p class="posts"><em>Сообщений:</em> 123</p>		
+		
+		<br>	</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">R.Richter &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89301576#89301576">22-Июн-26 21:09</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 12 мин., ред. 22-Июн-26 21:09)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89301576">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-21">
+						<div class="post_body" id="p-89301576" data-ext_link_data='{"p":89301576,"t":6873596,"f":252,"u":53582853}'>
+													<div class="q-wrap">
+<div class="q-head"><span><b>russvarg</b> писал(а):</span></div>
+<div class="q"><u class="q-post">89301495</u>Те кто называет фильм говном его не смотрели или просто фанаты советских фильмов.</div>
+</div>
+Если фанаты советских фильмов называют фильм говном, значит фильм говно.											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=53582853">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=53582853">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89301635" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89301635"></a>
+		
+		
+				<p class="nick ">mr.chonkin</p>
+		
+		
+								<p class="joined"><em>Стаж:</em> 13 лет 11 месяцев</p>		<p class="posts"><em>Сообщений:</em> 92</p>		
+		
+		<br>	</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">mr.chonkin &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89301635#89301635">22-Июн-26 21:28</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 18 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89301635">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-22">
+						<div class="post_body" id="p-89301635" data-ext_link_data='{"p":89301635,"t":6873596,"f":252,"u":27806245}'>
+													Сигурни Вывернет Матильду											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=27806245">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=27806245">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89301732" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89301732"></a>
+		
+		
+				<p class="nick ">vatanabi</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/3/16/15367716.jpg" alt=""></p>		<p class="joined"><em>Стаж:</em> 16 лет 4 месяца</p>		<p class="posts"><em>Сообщений:</em> 551</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">vatanabi &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89301732#89301732">22-Июн-26 22:03</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 35 мин., ред. 22-Июн-26 22:03)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89301732">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-23">
+						<div class="post_body" id="p-89301732" data-ext_link_data='{"p":89301732,"t":6873596,"f":252,"u":15367716}'>
+													Тяжело в шлеме ходить.. <img class="smile" src="https://static.rutracker.cc/smiles/icon_biggrin.gif" alt="">											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=15367716">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=15367716">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89301997" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89301997"></a>
+		
+		
+				<p class="nick ">g n</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/1/35/5755235.jpg" alt=""></p>		<p class="joined"><em>Стаж:</em> 17 лет 8 месяцев</p>		<p class="posts"><em>Сообщений:</em> 7</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">g n &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89301997#89301997">22-Июн-26 23:50</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 1 час 47 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89301997">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-24">
+						<div class="post_body" id="p-89301997" data-ext_link_data='{"p":89301997,"t":6873596,"f":252,"u":5755235}'>
+													херова.. гл героя зовут манда											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=5755235">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=5755235">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89302112" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89302112"></a>
+		
+		
+				<p class="nick ">mentalrisk2</p>
+		
+		
+								<p class="joined"><em>Стаж:</em> 14 лет 6 месяцев</p>		<p class="posts"><em>Сообщений:</em> 431</p>		
+		
+		<br>	</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">mentalrisk2 &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89302112#89302112">23-Июн-26 00:40</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 50 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89302112">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-25">
+						<div class="post_body" id="p-89302112" data-ext_link_data='{"p":89302112,"t":6873596,"f":252,"u":24733802}'>
+													"Новая Республика пытается защитить идеалы" - есть где в тексте эти идеалы, почитать?											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=24733802">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=24733802">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89302354" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89302354"></a>
+		
+		
+				<p class="nick ">999999999555<wbr>55</p>
+		
+		
+								<p class="joined"><em>Стаж:</em> 5 лет 8 месяцев</p>		<p class="posts"><em>Сообщений:</em> 28</p>		
+		
+		<br>	</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">999999999555<wbr>55 &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89302354#89302354">23-Июн-26 05:22</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 4 часа)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89302354">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-26">
+						<div class="post_body" id="p-89302354" data-ext_link_data='{"p":89302354,"t":6873596,"f":252,"u":45997030}'>
+													<div class="sp-wrap">
+<div class="sp-head folded"><span>скрытый текст</span></div>
+<div class="sp-body"><a href="https://fastpic.org/view/127/2026/0623/2bfb55748b7e74bf7e30b914a2151873.jpeg.html" class="postLink"><var class="postImg" title="https://i127.fastpic.org/big/2026/0623/73/2bfb55748b7e74bf7e30b914a2151873.jpeg">&#10;</var></a></div>
+</div>											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=45997030">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=45997030">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89302429" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89302429"></a>
+		
+		
+				<p class="nick ">andrewalexk</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/3/4/16961804.jpg" alt=""></p>		<p class="joined"><em>Стаж:</em> 16 лет 1 месяц</p>		<p class="posts"><em>Сообщений:</em> 106</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">andrewalexk &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89302429#89302429">23-Июн-26 06:46</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 1 час 23 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89302429">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-27">
+						<div class="post_body" id="p-89302429" data-ext_link_data='{"p":89302429,"t":6873596,"f":252,"u":16961804}'>
+													<img class="smile" src="https://static.rutracker.cc/smiles/icon_smile.gif" alt=""> не совсем понятна таргет-группа фильма... 6+?<br>
+так они все привыкли к компьютерной графике .. как их отцы<br>
+а тут куклы...											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=16961804">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=16961804">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89302514" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89302514"></a>
+		
+		
+				<p class="nick ">apleon</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/4/81/24588081.jpg" alt=""></p>		<p class="joined"><em>Стаж:</em> 14 лет 6 месяцев</p>		<p class="posts"><em>Сообщений:</em> 1222</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">apleon &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89302514#89302514">23-Июн-26 07:54</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 1 час 7 мин.)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89302514">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-28">
+						<div class="post_body" id="p-89302514" data-ext_link_data='{"p":89302514,"t":6873596,"f":252,"u":24588081}'>
+													<div class="q-wrap">
+<div class="q-head"><span><b>andrewalexk</b> писал(а):</span></div>
+<div class="q"><u class="q-post">89302429</u> <img class="smile" src="https://static.rutracker.cc/smiles/icon_smile.gif" alt=""> не совсем понятна таргет-группа фильма... 6+?<br>
+так они все привыкли к компьютерной графике .. как их отцы<br>
+а тут куклы...</div>
+</div>
+Это Дисней - у него группа 6-											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=24588081">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=24588081">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89302563" class="row1">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89302563"></a>
+		
+		
+				<p class="nick ">andy.andy</p>
+		
+		
+						<p class="avatar"><img src="https://static.rutracker.cc/avatars/4/37/24011337.jpg" alt=""></p>		<p class="joined"><em>Стаж:</em> 14 лет 7 месяцев</p>		<p class="posts"><em>Сообщений:</em> 3553</p>		
+		
+			</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">andy.andy &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89302563#89302563">23-Июн-26 08:34</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 40 мин., ред. 23-Июн-26 08:34)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89302563">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-29">
+						<div class="post_body" id="p-89302563" data-ext_link_data='{"p":89302563,"t":6873596,"f":252,"u":24011337}'>
+													<span class="post-b">99999999955555</span><br>
+знатно заморочился!
+<div class="q-wrap">
+<div class="q-head"><span><b>andrewalexk</b> писал(а):</span></div>
+<div class="q"><u class="q-post">89302429</u> <img class="smile" src="https://static.rutracker.cc/smiles/icon_smile.gif" alt=""> не совсем понятна таргет-группа фильма... 6+?<br>
+так они все привыкли к компьютерной графике .. как их отцы<br>
+а тут куклы...</div>
+</div>
+верняк! у Грогу как будто ревматизм с детства - весь обмороженый, да и другие "малыши"... видно, что куклы - Маппет-шоу в действии...<br>
+в кинцо вложились, а эти - деревянные все... <img class="smile" src="https://static.rutracker.cc/smiles/icon_confused.gif" alt="">											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=24011337">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=24011337">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+
+<tbody id="post_89302610" class="row2">
+<tr>
+	<td class="poster_info td1 hide-for-print">
+		<a id="89302610"></a>
+		
+		
+				<p class="nick ">vvaassyyaa</p>
+		
+		
+								<p class="joined"><em>Стаж:</em> 8 лет 11 месяцев</p>		<p class="posts"><em>Сообщений:</em> 56</p>		
+		
+		<br>	</td>
+	<td class="message td2" rowspan="2">
+
+		<div class="post_head">
+			<p class="post-time">
+								<span class="hl-scrolled-to-wrap">
+					<span class="show-for-print bold">vvaassyyaa &middot; </span>
+					<img src="https://static.rutracker.cc/templates/v1/images/icon_minipost.gif" class="icon1 hide-for-print" alt="">
+					<a class="p-link small" href="viewtopic.php?p=89302610#89302610">23-Июн-26 08:56</a>
+				</span>
+												<span class="posted_since hide-for-print">(спустя 22 мин., ред. 23-Июн-26 08:56)</span>
+							</p>
+
+			<ul class="inlined t-post-buttons hide-for-print" style="float: right; padding: 3px 2px 4px;">
+				
+												<li><a class="txtb" href="posting.php?mode=quote&amp;p=89302610">[Цитировать]</a></li>
+																							</ul>
+			<div class="clear"></div>
+		</div>
+
+		<div class="post_wrap" id="p-20862-30">
+						<div class="post_body" id="p-89302610" data-ext_link_data='{"p":89302610,"t":6873596,"f":252,"u":42451863}'>
+													Маппет-шоу на новый лад. Убогая кукла, не мог избавится от ощущения что у этого Грогу прям в жопе торчит рука кукловода, Педру Паскаля все упорно кличут "манда", сюжет никакущий...<br>
+Лучше уж Дарт Мол - повелитель теней смотреть, и то повеселее.<br>
+И глядя на этого Грогу и его прадеда Йоду наконец дошло что это за национальность. Это ж дети крокодила Гены и Чебурашки. Зеленые, маленькие, с большими ушами... Только вот кто кого - крокодил Чебурашку или наоборот пока не вкурил <img class="smile" src="https://static.rutracker.cc/smiles/icon_smile.gif" alt="">											</div><!--/post_body-->
+
+			
+					</div><!--/post_wrap-->
+
+		
+	</td>
+</tr>
+<tr>
+	<td class="poster_btn td3 hide-for-print">
+
+				<div style="padding: 2px 6px 4px;" class="post_btn_2">
+			<a class="txtb" href="profile.php?mode=viewprofile&amp;u=42451863">[Профиль]</a>&nbsp;
+			<a class="txtb" href="privmsg.php?mode=post&amp;u=42451863">[ЛС]</a>&nbsp;
+					</div>
+		
+	</td>
+</tr>
+</tbody>
+
+
+
+</table><!--/topic_main-->
+
+<script>$('img.smile').remove();</script>
+
+<table id="pagination" class="topic">
+<tr>
+	<td class="nav pad_6 row1">
+		<p style="float: left">Страница <b>1</b> из <b>2</b></p>
+		<p style="float: right" class="hide-for-print"><span class="pg-jump-menu"><a class="menu-root" href="#pg-jump" onclick="BB.focus_pg_input();">Страницы</a> :&nbsp;&nbsp;</span><b>1</b>, <a class="pg" href="viewtopic.php?t=6873596&amp;start=30">2</a>&nbsp;&nbsp;<a class="pg" href="viewtopic.php?t=6873596&amp;start=30">След.</a></p>
+	</td>
+</tr>
+</table><!--/pagination-->
+
+
+<table class="topic hide-for-print">
+<tr>
+	<td class="catBottom med">
+		&nbsp;
+	</td>
+</tr>
+</table>
+
+<table class="w100 hide-for-print" style="padding-top: 2px;">
+<tr>
+	<td class="vTop">
+		<a href="posting.php?mode=reply&amp;t=6873596"><img src="https://static.rutracker.cc/templates/v1/images/reply.gif" alt="Ответить"></a>
+	</td>
+	<td class="nav w100" style="padding-left: 8px;">
+		<a href="index.php">Главная</a>
+		<em>&raquo;</em> <a href="index.php?c=2">Кино, Видео и ТВ</a>
+				<em>&raquo;</em> <a href="viewforum.php?f=7">Зарубежное кино</a>
+				<em>&raquo;</em> <a href="viewforum.php?f=252">Фильмы 2026</a>
+	</td>
+</tr>
+</table>
+
+<div class="bottom_info hide-for-print">
+
+	<div class="tRight">
+		<span id="jumpbox-wrap"></span>
+	</div>
+
+	<table class="w100">
+	<tr>
+				<td class="tRight med vTop">
+					</td>
+	</tr>
+	</table>
+
+</div><!--/bottom_info-->
+
+
+
+				</div><!--/main_content_wrap-->
+			</td><!--/main_content-->
+
+		</tr>
+		</table>
+	</div><!--/page_content-->
+
+	<!--page_footer-->
+	<div id="page_footer" class="hide-for-print">
+
+		
+		<div class="clear"></div>
+
+		<nav id="footer-info-links">
+			<div>
+				<a href="info.php?show=user_agreement" rel="nofollow">Условия использования</a>
+				&middot;
+				<a href="info.php?show=advert" rel="nofollow">Реклама на сайте</a>
+				&middot;
+				<a href="info.php?show=copyright_holders" rel="nofollow">Для правообладателей</a>
+				&middot;
+				<a href="info.php?show=press" rel="nofollow">Для прессы</a>
+				&middot;
+				<a href="viewtopic.php?t=2234744">Для провайдеров</a>
+				<!--&middot;-->
+				<!--<a href="http://rutracker.news">Блог</a>-->
+				&middot;
+				<a href="https://rutracker.wiki">Торрентопедия</a>
+			</div>
+			<div>
+				<a href="viewtopic.php?t=1045"><b>Правила</b></a>
+				&middot;
+				<a href="/go/8" rel="nofollow">Кому задать вопрос</a>
+				&middot;
+				<a href="viewforum.php?f=1538">Авторские раздачи</a>
+				&middot;
+				<a href="viewforum.php?f=1289">Конкурсы</a>
+				&middot;
+				<a href="viewforum.php?f=2332">Новости &quot;Хранителей&quot; и &quot;Антикваров&quot;</a>
+				&middot;
+				<a href="#" onclick="return post2url('index.php', {rand_rel: 1});" rel="nofollow">Случайная раздача</a>
+			</div>
+		</nav>
+
+		
+		<div class="tCenter nowrap" style="margin: 18px 4px 4px 4px;">
+								</div>
+
+		<div class="footer-bottom-links">
+			<ul class="inlined middot-separated">
+				<li><a href="groupcp.php?g=104792" rel="nofollow" target="_blank">Администрация</a></li>
+				<li><a href="groupcp.php?g=104787" rel="nofollow" target="_blank">Модераторы</a></li>
+				<li><a href="groupcp.php?g=104841" rel="nofollow" target="_blank">Тех. помощь</a></li>
+				<li><a href="https://t.me/rutracker_news" rel="nofollow" target="_blank">Telegram-канал</a></li>
+			</ul>
+			<div class="wide">
+									<script>
+					$(function () {
+						var title = "";
+						var src = "https://counter.yadro.ru/hit?t44.1;r" + encodeURIComponent(document.referrer) +
+							((typeof (screen) == "undefined") ? "" : ";s" + screen.width + "*" + screen.height + "*" + (screen.colorDepth ? screen.colorDepth : screen.pixelDepth)) +
+							";u" + encodeURIComponent(document.URL) + ";h" + encodeURIComponent(title.substring(0, 80)) + ";" + Math.random();
+						$('<img src="' + src + '" alt="">').on('load', function () {
+							$('#liveinternet').append(this);
+						});
+					});
+					</script>
+					<a id="liveinternet" href="https://www.liveinternet.ru/stat/rutracker.org/index.html?lang=ru" target="_blank"></a>
+							</div>
+			<ul class="inlined middot-separated">
+																							</ul>
+		</div>
+
+	</div><!--/page_footer-->
+</div><!--/page_container-->
+
+
+<div id="ajax-loading"><b>Loading...</b></div>
+<div id="ajax-error"><b>Error</b></div>
+<style>
+#bb-alert-box {
+	width: auto;
+	max-width: 800px;
+	line-height: 18px;
+	display: none;
+}
+#bb-alert-msg {
+	min-width: 400px;
+	max-height: 400px;
+	margin: 50px 20px;
+	padding: 10px;
+	overflow: auto;
+	text-align: center;
+}
+.bb-alert-err {
+	color: #7E0000;
+	background: #FFEEEE;
+	box-shadow: 0 0 20px #B85353;
+	font-weight: bold;
+}
+</style>
+<div id="bb-alert-box">
+	<div id="bb-alert-msg"></div>
+</div>
+<div id="modal-blocker"></div>
+
+<script>
+$(function () {
+	if (!BB.hasET() && BB.getUrlParam('view') !== 'print') {
+		BB.navbar.init();
+	}
+});
+</script>
+<div id="nav-panel" class="nav-hidden-arrow hide-for-print">
+	<div id="nav-up" class="nav-btn" title="Вверх">
+		<span class="nav-icon"></span>
+	</div>
+	<div id="nav-settings" class="nav-btn">
+		<span class="nav-icon" title="Настройки"></span>
+		<ul id="nav-opt-menu">
+			<li class="nav-event" data-event="click">Показывать по клику</li>
+			<li class="nav-event" data-event="mouseenter">Показывать по наведению</li>
+		</ul>
+	</div>
+	<div id="nav-down" class="nav-btn" title="Вниз">
+		<span class="nav-icon"></span>
+	</div>
+	<div class="nav-hidden-overlay"></div>
+</div>
+
+	</div><!--/body_container-->
+
+<script>(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML="window.__CF$cv$params={r:'a106510659544a25',t:'MTc4MjI0NzMxNw=='};var a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);";b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script></body>
+</html>


### PR DESCRIPTION
## Step 1 of decoupling parsing from app releases

Goal of the whole effort: be able to change rutracker parsing rules **without shipping a new release**, by eventually swapping in a config-driven parser. This PR builds the seam that makes that swap a one-line change, and pins current behaviour with tests on real pages.

### What this PR does

- **New `RuTrackerParser` interface** — a pure `String html → DTO / Boolean` contract, no network, no IO. It's the single place that holds all markup/text knowledge.
- **`RuTrackerHtmlParser`** (ksoup) implements it, keeping the focused `Parse*UseCase` objects as the internal building blocks it delegates to (`ParseTopicPageUseCase`, `ParseCommentsPageUseCase`, `ParseTorrentUseCase`, `ParsePostUseCase`, `ParseTorrentStatusUseCase`).
- **Use cases become "fetch + delegate":** the page-parsing use cases (search, category, forum, topic, comments, torrent, profile, current-user, favorites) and the page-state checks now call the parser instead of parsing inline. Parsing logic that was inlined in `Get*UseCase` / `Utils` moved into the parser.
- **`RuTrackerApiFactory`** constructs the parser and injects it — this is the line Step 3 will swap.
- **Public `NetworkApi` contract is unchanged** → blast radius stays inside `:core:network:rutracker`.

### Tests (TDD on real HTML)

Characterization tests run against real saved rutracker pages in `src/test/resources/fixtures/` — `:core:network:rutracker:test` is green (9/9). Covered: `parseForum`, `parseCategoryPage`, `parseTorrent`, `parseTopicPage`, `parseCommentsPage` (incl. quote/spoiler/image post content), `parseProfile`, and the `topic-exists` / `forum-exists` / `is-authorized` / `is-torrent-topic` states.

### Known gap — authenticated fixtures needed

The `search` / `favorites` / `main_authorized` captures came back as **login stubs** (the session cookie wasn't authenticated — no `logged-in-username` anywhere), so these parsers aren't test-covered yet:

- `parseSearchPage`, `parseFavorites` (+ page count), `parseCurrentUserId`, `isAuthorized == true`
- the authenticated topic branch (`#tor-status-resp` status + `#tor-size-humn` size)

The interface methods exist and are implemented; tests will be added once authenticated fixtures are re-captured. The auth/login/form-token/captcha/action-result callers (`WithFormTokenUseCase`, `LoginUseCase`, add/remove favorite, add comment) are also still inline — they'll be routed through the parser in a follow-up increment.

### Next

- **Step 2:** design the versioned parsing config and a config-driven `RuTrackerParser` (also TDD against these same fixtures).
- **Step 3:** swap the implementation in `RuTrackerApiFactory`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPxhiZbmURTJvhRzAHcpGu

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPxhiZbmURTJvhRzAHcpGu)_